### PR TITLE
Temporarily add writeToDisk to webpack-dev-server config to restore hot reloading

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,26 +1,26 @@
 /* eslint-env node */
 
-import { Configuration as WebpackConfiguration } from "webpack";
-import { Configuration as WebpackDevServerConfiguration } from "webpack-dev-server";
-import * as path from "path";
-import { ConsoleRemotePlugin } from "@openshift-console/dynamic-plugin-sdk-webpack";
+import { Configuration as WebpackConfiguration } from 'webpack';
+import { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
+import * as path from 'path';
+import { ConsoleRemotePlugin } from '@openshift-console/dynamic-plugin-sdk-webpack';
 
 interface Configuration extends WebpackConfiguration {
   devServer?: WebpackDevServerConfiguration;
 }
 
 const config: Configuration = {
-  mode: "development",
+  mode: 'development',
   // No regular entry points. The remote container entry is handled by ConsoleRemotePlugin.
   entry: {},
-  context: path.resolve(__dirname, "src"),
+  context: path.resolve(__dirname, 'src'),
   output: {
-    path: path.resolve(__dirname, "dist"),
-    filename: "[name]-bundle.js",
-    chunkFilename: "[name]-chunk.js",
+    path: path.resolve(__dirname, 'dist'),
+    filename: '[name]-bundle.js',
+    chunkFilename: '[name]-chunk.js',
   },
   resolve: {
-    extensions: [".ts", ".tsx", ".js", ".jsx"],
+    extensions: ['.ts', '.tsx', '.js', '.jsx'],
   },
   module: {
     rules: [
@@ -29,22 +29,22 @@ const config: Configuration = {
         exclude: /node_modules/,
         use: [
           {
-            loader: "ts-loader",
+            loader: 'ts-loader',
             options: {
-              configFile: path.resolve(__dirname, "tsconfig.json"),
+              configFile: path.resolve(__dirname, 'tsconfig.json'),
             },
           },
         ],
       },
       {
         test: /\.css$/,
-        use: ["style-loader", "css-loader"],
+        use: ['style-loader', 'css-loader'],
       },
       {
         test: /\.(png|jpg|jpeg|gif|svg|woff2?|ttf|eot|otf)(\?.*$|$)/,
-        loader: "file-loader",
+        loader: 'file-loader',
         options: {
-          name: "assets/[name].[ext]",
+          name: 'assets/[name].[ext]',
         },
       },
       {
@@ -59,24 +59,24 @@ const config: Configuration = {
     static: './dist',
     port: 9001,
     headers: {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",
-      "Access-Control-Allow-Headers": "X-Requested-With, Content-Type, Authorization"
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
+      'Access-Control-Allow-Headers': 'X-Requested-With, Content-Type, Authorization',
     },
   },
   plugins: [new ConsoleRemotePlugin()],
-  devtool: "source-map",
+  devtool: 'source-map',
   optimization: {
-    chunkIds: "named",
+    chunkIds: 'named',
     minimize: false,
   },
 };
 
-if (process.env.NODE_ENV === "production") {
-  config.mode = "production";
-  config.output.filename = "[name]-bundle-[hash].min.js";
-  config.output.chunkFilename = "[name]-chunk-[chunkhash].min.js";
-  config.optimization.chunkIds = "deterministic";
+if (process.env.NODE_ENV === 'production') {
+  config.mode = 'production';
+  config.output.filename = '[name]-bundle-[hash].min.js';
+  config.output.chunkFilename = '[name]-chunk-[chunkhash].min.js';
+  config.optimization.chunkIds = 'deterministic';
   config.optimization.minimize = true;
 }
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -63,6 +63,9 @@ const config: Configuration = {
       'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
       'Access-Control-Allow-Headers': 'X-Requested-With, Content-Type, Authorization',
     },
+    devMiddleware: {
+      writeToDisk: true,
+    },
   },
   plugins: [new ConsoleRemotePlugin()],
   devtool: 'source-map',


### PR DESCRIPTION
Hot reloading is not working for me, and this config change fixes it for now. We shouldn't need WDS to be writing to disk (it's slower than the default behavior of serving from RAM) so we should remove this eventually.

See discussion on Slack: https://coreos.slack.com/archives/C011BL0FEKZ/p1642455506077200