### PR TITLE
Implement initial Edit PVs form presentation layer and state (editable table mechanism w/ wizard nav, row-specific form fields)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@openshift-console/dynamic-plugin-sdk": "0.0.3",
     "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.4",
     "@patternfly/react-core": "^4.181.1",
+    "@patternfly/react-icons": "^4.43.15",
     "@patternfly/react-table": "^4.61.15",
     "@types/node": "^16.11.13",
     "@types/react": "^17.0.38",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@patternfly/react-core": "^4.181.1",
     "@patternfly/react-icons": "^4.43.15",
     "@patternfly/react-table": "^4.61.15",
+    "@patternfly/react-tokens": "^4.44.15",
     "@types/node": "^16.11.13",
     "@types/react": "^17.0.38",
     "@types/react-helmet": "^6.1.5",

--- a/src/common/components/SimpleSelectMenu.tsx
+++ b/src/common/components/SimpleSelectMenu.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { MenuToggle, Menu, Popper, MenuToggleProps } from '@patternfly/react-core';
+import { MenuToggle, Menu, Popper, MenuToggleProps, MenuProps } from '@patternfly/react-core';
 
 // Based on https://www.patternfly.org/v4/demos/composable-menu#select-menu
 
-interface SimpleSelectMenuProps<T extends string | number> {
+interface SimpleSelectMenuProps<T extends string | number> extends MenuProps {
   selected: T;
   setSelected: (value: T) => void;
   children: React.ReactNode;
@@ -15,6 +15,7 @@ export const SimpleSelectMenu = <T extends string | number>({
   setSelected,
   children,
   toggleProps = {},
+  ...props
 }: React.PropsWithChildren<SimpleSelectMenuProps<T>>): JSX.Element | null => {
   const [isOpen, setIsOpen] = React.useState(false);
   const toggleRef = React.useRef<HTMLButtonElement>();
@@ -22,15 +23,15 @@ export const SimpleSelectMenu = <T extends string | number>({
 
   React.useEffect(() => {
     const handleMenuKeys = (event: KeyboardEvent) => {
-      if (isOpen && menuRef.current.contains(event.target as Node)) {
+      if (isOpen && menuRef.current?.contains(event.target as Node)) {
         if (event.key === 'Escape' || event.key === 'Tab') {
           setIsOpen(!isOpen);
-          toggleRef.current.focus();
+          toggleRef.current?.focus();
         }
       }
     };
     const handleClickOutside = (event: MouseEvent) => {
-      if (isOpen && !menuRef.current.contains(event.target as Node)) {
+      if (isOpen && !menuRef.current?.contains(event.target as Node)) {
         setIsOpen(false);
       }
     };
@@ -67,6 +68,7 @@ export const SimpleSelectMenu = <T extends string | number>({
         setIsOpen(false);
       }}
       selected={selected}
+      {...props}
     >
       {children}
     </Menu>

--- a/src/components/ImportWizard/ImportWizardFormContext.tsx
+++ b/src/components/ImportWizard/ImportWizardFormContext.tsx
@@ -15,8 +15,10 @@ export const useImportWizardFormState = () => {
     setValue: (selectedPVs: PersistentVolume[]) => {
       baseSelectedPVsField.setValue(selectedPVs);
       // When selected PVs change, initialize the per-PV form values for the Edit PVs step
+      const defaultIsEditModeByPV: PVIsEditModeByPVName = {};
       const defaultEditValuesByPV: PVEditValuesByPVName = {};
       selectedPVs.forEach((pv) => {
+        defaultIsEditModeByPV[pv.metadata.name] = false;
         const defaultEditValues: PVEditRowFormValues = {
           targetPvcName: pv.spec.claimRef.name,
           storageClass: defaultStorageClass.metadata.name,
@@ -26,10 +28,15 @@ export const useImportWizardFormState = () => {
         defaultEditValuesByPV[pv.metadata.name] =
           editValuesByPVField.value[pv.metadata.name] || defaultEditValues;
       });
+      isEditModeByPVField.reinitialize(defaultIsEditModeByPV);
       editValuesByPVField.reinitialize(defaultEditValuesByPV);
     },
   };
 
+  const isEditModeByPVField = useFormField<PVIsEditModeByPVName>(
+    {},
+    yup.mixed<PVIsEditModeByPVName>(),
+  );
   const editValuesByPVField = useFormField<PVEditValuesByPVName>(
     {},
     yup.mixed<PVEditValuesByPVName>().required(),
@@ -45,7 +52,8 @@ export const useImportWizardFormState = () => {
       selectedPVs: selectedPVsField,
     }),
     pvEdit: useFormState({
-      valuesByPV: editValuesByPVField,
+      isEditModeByPV: isEditModeByPVField,
+      editValuesByPV: editValuesByPVField,
     }),
     pipelineSettings: useFormState({}),
   };
@@ -75,3 +83,4 @@ export const usePVEditRowFormState = (existingValues: PVEditRowFormValues) => {
 };
 
 export type PVEditValuesByPVName = Record<string, PVEditRowFormValues>;
+export type PVIsEditModeByPVName = Record<string, boolean>;

--- a/src/components/ImportWizard/ImportWizardFormContext.tsx
+++ b/src/components/ImportWizard/ImportWizardFormContext.tsx
@@ -20,7 +20,7 @@ export const useImportWizardFormState = () => {
         const defaultEditValues: PVEditRowFormValues = {
           targetPvcName: pv.spec.claimRef.name,
           storageClass: defaultStorageClass.metadata.name,
-          capacity: '',
+          capacity: pv.spec.capacity.storage, // TODO format? suffix?
           verifyCopy: false,
         };
         defaultEditValuesByPV[pv.metadata.name] =

--- a/src/components/ImportWizard/ImportWizardFormContext.tsx
+++ b/src/components/ImportWizard/ImportWizardFormContext.tsx
@@ -4,6 +4,7 @@ import { useFormField, useFormState } from '@konveyor/lib-ui';
 import { PersistentVolume } from 'src/types/PersistentVolume';
 
 export const useImportWizardFormState = () => {
+  // TODO move the setSelectedPVsAndPrefillEdit behavior from PVSelectStep here somehow? replace the setValue? useEffect?
   const selectedPVsField = useFormField<PersistentVolume[]>([], yup.array().required().min(1));
   return {
     sourceClusterProject: useFormState({

--- a/src/components/ImportWizard/ImportWizardFormContext.tsx
+++ b/src/components/ImportWizard/ImportWizardFormContext.tsx
@@ -3,21 +3,59 @@ import * as yup from 'yup';
 import { useFormField, useFormState } from '@konveyor/lib-ui';
 import { PersistentVolume } from 'src/types/PersistentVolume';
 
-export const useImportWizardFormState = () => ({
-  sourceClusterProject: useFormState({
-    apiUrl: useFormField('', yup.string().label('Cluster API URL').required()), // TODO format validation, and async connection validation?
-    token: useFormField('', yup.string().label('OAuth token').required()), // TODO format validation, and async connection validation?
-    namespace: useFormField('', yup.string().label('Project name').required()), // TODO format validation, and async exists validation?
-  }),
-  pvSelect: useFormState({
-    selectedPVs: useFormField<PersistentVolume[]>([], yup.array().required().min(1)),
-  }),
-  pvEdit: useFormState({}),
-  pipelineSettings: useFormState({}),
-});
+export const useImportWizardFormState = () => {
+  const selectedPVsField = useFormField<PersistentVolume[]>([], yup.array().required().min(1));
+  return {
+    sourceClusterProject: useFormState({
+      apiUrl: useFormField('', yup.string().label('Cluster API URL').required()), // TODO format validation, and async connection validation?
+      token: useFormField('', yup.string().label('OAuth token').required()), // TODO format validation, and async connection validation?
+      namespace: useFormField('', yup.string().label('Project name').required()), // TODO format validation, and async exists validation?
+    }),
+    pvSelect: useFormState({
+      selectedPVs: selectedPVsField,
+    }),
+    pvEdit: useFormState({
+      valuesByPVName: useFormField<PVEditValuesByPVName>(
+        {},
+        yup.mixed<PVEditValuesByPVName>().required(),
+      ),
+    }),
+    pipelineSettings: useFormState({}),
+  };
+};
 
 export type ImportWizardFormState = ReturnType<typeof useImportWizardFormState>;
 
 export const ImportWizardFormContext = React.createContext<ImportWizardFormState>(
   {} as ImportWizardFormState,
 );
+
+export interface PVEditRowFormValues {
+  targetPvcName: string;
+  storageClass: string;
+  capacity: string;
+  verifyCopy: boolean;
+}
+
+export const usePVEditRowFormState = (existing: PVEditRowFormValues) =>
+  useFormState<PVEditRowFormValues>({
+    targetPvcName: useFormField(
+      existing.targetPvcName,
+      yup.string().label('Target PVC name').required(),
+    ), // TODO format validation, check it doesn't already exist?
+    storageClass: useFormField(
+      existing.storageClass,
+      yup.string().label('Storage class').required(),
+    ), // TODO find real default value and type, validate it exists?
+    capacity: useFormField(existing.capacity, yup.string().label('Capacity').required()), // TODO format validation? other validation / min / max?
+    verifyCopy: useFormField(existing.verifyCopy, yup.boolean().label('Verify copy').required()),
+  });
+
+export type PVEditValuesByPVName = Record<string, PVEditRowFormValues>;
+
+export const getDefaultEditValuesForPV = (pv: PersistentVolume): PVEditRowFormValues => ({
+  targetPvcName: pv.spec.claimRef.name,
+  storageClass: '',
+  capacity: '',
+  verifyCopy: false,
+});

--- a/src/components/ImportWizard/ImportWizardFormContext.tsx
+++ b/src/components/ImportWizard/ImportWizardFormContext.tsx
@@ -2,19 +2,24 @@ import * as React from 'react';
 import * as yup from 'yup';
 import { useFormField, useFormState } from '@konveyor/lib-ui';
 import { PersistentVolume } from 'src/types/PersistentVolume';
+import { MOCK_STORAGE_CLASSES } from 'src/mock/StorageClasses.mock';
 
 export const useImportWizardFormState = () => {
+  // TODO load this from the host cluster via the SDK
+  const storageClasses = MOCK_STORAGE_CLASSES; // TODO do we need to pass this in? call the SDK hook here?
+  const defaultStorageClass = storageClasses[0]; // TODO how to determine this?
+
   const baseSelectedPVsField = useFormField<PersistentVolume[]>([], yup.array().required().min(1));
   const selectedPVsField = {
     ...baseSelectedPVsField,
     setValue: (selectedPVs: PersistentVolume[]) => {
       baseSelectedPVsField.setValue(selectedPVs);
       // When selected PVs change, initialize the per-PV form values for the Edit PVs step
-      const defaultEditValuesByPV = {};
+      const defaultEditValuesByPV: PVEditValuesByPVName = {};
       selectedPVs.forEach((pv) => {
-        const defaultEditValues = {
+        const defaultEditValues: PVEditRowFormValues = {
           targetPvcName: pv.spec.claimRef.name,
-          storageClass: '',
+          storageClass: defaultStorageClass.metadata.name,
           capacity: '',
           verifyCopy: false,
         };
@@ -24,10 +29,12 @@ export const useImportWizardFormState = () => {
       editValuesByPVField.reinitialize(defaultEditValuesByPV);
     },
   };
+
   const editValuesByPVField = useFormField<PVEditValuesByPVName>(
     {},
     yup.mixed<PVEditValuesByPVName>().required(),
   );
+
   return {
     sourceClusterProject: useFormState({
       apiUrl: useFormField('', yup.string().label('Cluster API URL').required()), // TODO format validation, and async connection validation?
@@ -57,18 +64,14 @@ export interface PVEditRowFormValues {
   verifyCopy: boolean;
 }
 
-export const usePVEditRowFormState = (existing: PVEditRowFormValues) =>
-  useFormState<PVEditRowFormValues>({
-    targetPvcName: useFormField(
-      existing.targetPvcName,
-      yup.string().label('Target PVC name').required(),
-    ), // TODO format validation, check it doesn't already exist?
-    storageClass: useFormField(
-      existing.storageClass,
-      yup.string().label('Storage class').required(),
-    ), // TODO find real default value and type, validate it exists?
-    capacity: useFormField(existing.capacity, yup.string().label('Capacity').required()), // TODO format validation? other validation / min / max?
-    verifyCopy: useFormField(existing.verifyCopy, yup.boolean().label('Verify copy').required()),
+export const usePVEditRowFormState = (existingValues: PVEditRowFormValues) => {
+  const { targetPvcName, storageClass, capacity, verifyCopy } = existingValues;
+  return useFormState<PVEditRowFormValues>({
+    targetPvcName: useFormField(targetPvcName, yup.string().label('Target PVC name').required()), // TODO format validation, check it doesn't already exist?
+    storageClass: useFormField(storageClass, yup.string().label('Storage class').required()), // TODO find real default value and type, validate it exists?
+    capacity: useFormField(capacity, yup.string().label('Capacity').required()), // TODO format validation? other validation / min / max?
+    verifyCopy: useFormField(verifyCopy, yup.boolean().label('Verify copy').required()),
   });
+};
 
 export type PVEditValuesByPVName = Record<string, PVEditRowFormValues>;

--- a/src/components/ImportWizard/PVEditStep.tsx
+++ b/src/components/ImportWizard/PVEditStep.tsx
@@ -53,11 +53,18 @@ export const PVEditStep: React.FunctionComponent = () => {
               <PVEditStepTableRow
                 key={pv.metadata.name}
                 pv={pv}
-                existingValues={form.values.valuesByPV[pv.metadata.name]}
+                existingValues={form.values.editValuesByPV[pv.metadata.name]}
                 setEditedValues={(newValues) => {
-                  form.fields.valuesByPV.setValue((oldValues) => ({
+                  form.fields.editValuesByPV.setValue((oldValues) => ({
                     ...oldValues,
                     [pv.metadata.name]: newValues,
+                  }));
+                }}
+                isEditMode={form.values.isEditModeByPV[pv.metadata.name]}
+                setIsEditMode={(isEditMode) => {
+                  form.fields.isEditModeByPV.setValue((oldValues) => ({
+                    ...oldValues,
+                    [pv.metadata.name]: isEditMode,
                   }));
                 }}
               />

--- a/src/components/ImportWizard/PVEditStep.tsx
+++ b/src/components/ImportWizard/PVEditStep.tsx
@@ -44,7 +44,7 @@ export const PVEditStep: React.FunctionComponent = () => {
               <Th>{columnNames.targetPvcName}</Th>
               <Th width={20}>{columnNames.storageClass}</Th>
               <Th>{columnNames.capacity}</Th>
-              <Th>{columnNames.verifyCopy}</Th>
+              <Th textCenter>{columnNames.verifyCopy}</Th>
               <Th />
             </Tr>
           </Thead>

--- a/src/components/ImportWizard/PVEditStep.tsx
+++ b/src/components/ImportWizard/PVEditStep.tsx
@@ -42,7 +42,7 @@ export const PVEditStep: React.FunctionComponent = () => {
             <Tr>
               <Th sort={{ sortBy, onSort, columnIndex: 0 }}>{columnNames.sourcePvcName}</Th>
               <Th>{columnNames.targetPvcName}</Th>
-              <Th>{columnNames.storageClass}</Th>
+              <Th width={20}>{columnNames.storageClass}</Th>
               <Th>{columnNames.capacity}</Th>
               <Th>{columnNames.verifyCopy}</Th>
               <Th />

--- a/src/components/ImportWizard/PVEditStep.tsx
+++ b/src/components/ImportWizard/PVEditStep.tsx
@@ -53,9 +53,9 @@ export const PVEditStep: React.FunctionComponent = () => {
               <PVEditStepTableRow
                 key={pv.metadata.name}
                 pv={pv}
-                existingValues={form.values.valuesByPVName[pv.metadata.name]}
+                existingValues={form.values.valuesByPV[pv.metadata.name]}
                 setEditedValues={(newValues) => {
-                  form.fields.valuesByPVName.setValue((oldValues) => ({
+                  form.fields.valuesByPV.setValue((oldValues) => ({
                     ...oldValues,
                     [pv.metadata.name]: newValues,
                   }));

--- a/src/components/ImportWizard/PVEditStep.tsx
+++ b/src/components/ImportWizard/PVEditStep.tsx
@@ -3,17 +3,69 @@ import { TextContent, Text, Form } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 import { ImportWizardFormContext } from './ImportWizardFormContext';
+import { TableComposable, Thead, Tr, Th, Tbody } from '@patternfly/react-table';
+import { useSortState } from 'src/common/hooks/useSortState';
+
+import { PVEditStepTableRow } from './PVEditStepTableRow';
+
+export const columnNames = {
+  sourcePvcName: 'Source PVC name',
+  targetPvcName: 'Target PVC name',
+  storageClass: 'Storage class',
+  capacity: 'Capacity',
+  verifyCopy: 'Verify copy',
+};
 
 export const PVEditStep: React.FunctionComponent = () => {
-  const form = React.useContext(ImportWizardFormContext).pvEdit;
-  console.log('pvs edit form', form);
+  const forms = React.useContext(ImportWizardFormContext);
+  const form = forms.pvEdit;
+  const { selectedPVs } = forms.pvSelect.values;
+
+  // TODO filter state -- move to lib-ui and add generics?
+  const { sortBy, onSort, sortedItems } = useSortState(selectedPVs, (pv) => [
+    pv.spec.claimRef.name,
+  ]);
 
   return (
     <>
       <TextContent className={spacing.mbMd}>
         <Text component="h2">Edit PVs</Text>
+        <Text component="p">
+          Change properties of persistent volumes when copied to the target project. Also, select
+          whether the copy should be verified on the target.
+        </Text>
       </TextContent>
-      <Form>TODO: form fields for edit PVs</Form>
+      {/* TODO FilterToolbar -- do we want to actually move it to lib-ui now? */}
+      {/* TODO do we need to remove the border on the bottom of the header row as in the mockups? */}
+      <Form>
+        <TableComposable borders={false} variant="compact">
+          <Thead>
+            <Tr>
+              <Th sort={{ sortBy, onSort, columnIndex: 0 }}>{columnNames.sourcePvcName}</Th>
+              <Th>{columnNames.targetPvcName}</Th>
+              <Th>{columnNames.storageClass}</Th>
+              <Th>{columnNames.capacity}</Th>
+              <Th>{columnNames.verifyCopy}</Th>
+              <Th />
+            </Tr>
+          </Thead>
+          <Tbody>
+            {sortedItems.map((pv) => (
+              <PVEditStepTableRow
+                key={pv.metadata.name}
+                pv={pv}
+                existingValues={form.values.valuesByPVName[pv.metadata.name]}
+                setEditedValues={(newValues) => {
+                  form.fields.valuesByPVName.setValue((oldValues) => ({
+                    ...oldValues,
+                    [pv.metadata.name]: newValues,
+                  }));
+                }}
+              />
+            ))}
+          </Tbody>
+        </TableComposable>
+      </Form>
     </>
   );
 };

--- a/src/components/ImportWizard/PVEditStep.tsx
+++ b/src/components/ImportWizard/PVEditStep.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { TextContent, Text, Form } from '@patternfly/react-core';
+import { TableComposable, Thead, Tr, Th, Tbody } from '@patternfly/react-table';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
-import { ImportWizardFormContext } from './ImportWizardFormContext';
-import { TableComposable, Thead, Tr, Th, Tbody } from '@patternfly/react-table';
 import { useSortState } from 'src/common/hooks/useSortState';
-
+import { ImportWizardFormContext } from './ImportWizardFormContext';
 import { PVEditStepTableRow } from './PVEditStepTableRow';
 
 export const columnNames = {
@@ -29,7 +28,7 @@ export const PVEditStep: React.FunctionComponent = () => {
   return (
     <>
       <TextContent className={spacing.mbMd}>
-        <Text component="h2">Edit PVs</Text>
+        <Text component="h2">Edit persistent volumes</Text>
         <Text component="p">
           Change properties of persistent volumes when copied to the target project. Also, select
           whether the copy should be verified on the target.

--- a/src/components/ImportWizard/PVEditStepTableRow.tsx
+++ b/src/components/ImportWizard/PVEditStepTableRow.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Tr, Td } from '@patternfly/react-table';
-import { Button, MenuContent, MenuItem, MenuList } from '@patternfly/react-core';
+import { Button, Checkbox, MenuContent, MenuItem, MenuList } from '@patternfly/react-core';
 import PencilAltIcon from '@patternfly/react-icons/dist/esm/icons/pencil-alt-icon';
 import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
@@ -37,7 +37,10 @@ export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps
       <Td dataLabel={columnNames.sourcePvcName}>{pv.spec.claimRef.name}</Td>
       <Td dataLabel={columnNames.targetPvcName}>
         {isEditMode ? (
-          <ValidatedTextInput field={rowForm.fields.targetPvcName} fieldId="target-pvc-name" />
+          <ValidatedTextInput
+            field={rowForm.fields.targetPvcName}
+            fieldId={`target-pvc-name-${pv.spec.claimRef.name}`}
+          />
         ) : (
           existingValues.targetPvcName
         )}
@@ -48,6 +51,7 @@ export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps
             selected={rowForm.values.storageClass}
             setSelected={rowForm.fields.storageClass.setValue}
             toggleProps={{ style: { width: '100%' } }}
+            id={`storage-class-select-${pv.spec.claimRef.name}`}
           >
             <MenuContent>
               <MenuList>
@@ -65,12 +69,23 @@ export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps
       </Td>
       <Td dataLabel={columnNames.capacity}>
         {isEditMode ? (
-          <ValidatedTextInput field={rowForm.fields.capacity} fieldId="capacity" />
+          <ValidatedTextInput
+            field={rowForm.fields.capacity}
+            fieldId={`capacity-${pv.spec.claimRef.name}`}
+          />
         ) : (
           existingValues.capacity
         )}
       </Td>
-      <Td dataLabel={columnNames.verifyCopy}>TODO</Td>
+      <Td dataLabel={columnNames.verifyCopy} textCenter>
+        <Checkbox
+          aria-label={`Verify copy for PVC ${pv.spec.claimRef.name}`}
+          isDisabled={!isEditMode}
+          isChecked={rowForm.values.verifyCopy}
+          onChange={rowForm.fields.verifyCopy.setValue}
+          id={`verify-copy-${pv.spec.claimRef.name}`}
+        />
+      </Td>
       <Td modifier="nowrap">
         {!isEditMode ? (
           <Button

--- a/src/components/ImportWizard/PVEditStepTableRow.tsx
+++ b/src/components/ImportWizard/PVEditStepTableRow.tsx
@@ -61,7 +61,13 @@ export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps
           existingValues.storageClass
         )}
       </Td>
-      <Td dataLabel={columnNames.capacity}>TODO: TextInput</Td>
+      <Td dataLabel={columnNames.capacity}>
+        {isEditMode ? (
+          <ValidatedTextInput field={rowForm.fields.capacity} fieldId="capacity" />
+        ) : (
+          existingValues.capacity
+        )}
+      </Td>
       <Td dataLabel={columnNames.verifyCopy}>TODO</Td>
       <Td modifier="nowrap">
         {!isEditMode ? (
@@ -83,6 +89,7 @@ export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps
                 setEditedValues(rowForm.values);
                 setIsEditMode(!isEditMode);
               }}
+              isDisabled={!rowForm.isValid}
             />
             <Button
               variant="plain"

--- a/src/components/ImportWizard/PVEditStepTableRow.tsx
+++ b/src/components/ImportWizard/PVEditStepTableRow.tsx
@@ -16,19 +16,21 @@ interface PVEditStepTableRowProps {
   pv: PersistentVolume;
   existingValues: PVEditRowFormValues;
   setEditedValues: (values: PVEditRowFormValues) => void;
+  isEditMode: boolean;
+  setIsEditMode: (isEditMode: boolean) => void;
 }
 
 export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps> = ({
   pv,
   existingValues,
   setEditedValues,
+  isEditMode,
+  setIsEditMode,
 }) => {
   // TODO load this from the host cluster via the SDK
   const storageClasses = MOCK_STORAGE_CLASSES;
 
   const rowForm = usePVEditRowFormState(existingValues);
-
-  const [isEditMode, setIsEditMode] = React.useState(false);
 
   return (
     <Tr key={pv.metadata.name}>
@@ -75,7 +77,7 @@ export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps
             variant="link"
             icon={<PencilAltIcon />}
             iconPosition="right"
-            onClick={() => setIsEditMode(!isEditMode)}
+            onClick={() => setIsEditMode(true)}
           >
             Edit
           </Button>
@@ -87,7 +89,7 @@ export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps
               onClick={() => {
                 rowForm.markSaved();
                 setEditedValues(rowForm.values);
-                setIsEditMode(!isEditMode);
+                setIsEditMode(false);
               }}
               isDisabled={!rowForm.isValid}
             />
@@ -97,7 +99,7 @@ export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps
               onClick={() => {
                 rowForm.revert();
                 setEditedValues(existingValues);
-                setIsEditMode(!isEditMode);
+                setIsEditMode(false);
               }}
             >
               <TimesIcon />

--- a/src/components/ImportWizard/PVEditStepTableRow.tsx
+++ b/src/components/ImportWizard/PVEditStepTableRow.tsx
@@ -54,10 +54,7 @@ export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps
               variant="link"
               icon={<CheckIcon />}
               onClick={() => {
-                // Save edits
-                Object.keys(rowForm.values).forEach((key) =>
-                  rowForm.fields[key].prefill(rowForm.values[key]),
-                );
+                rowForm.markSaved();
                 setEditedValues(rowForm.values);
                 setIsEditMode(!isEditMode);
               }}
@@ -66,7 +63,6 @@ export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps
               variant="plain"
               icon={<TimesIcon />}
               onClick={() => {
-                // Cancel edits
                 rowForm.revert();
                 setEditedValues(existingValues);
                 setIsEditMode(!isEditMode);

--- a/src/components/ImportWizard/PVEditStepTableRow.tsx
+++ b/src/components/ImportWizard/PVEditStepTableRow.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react';
 import { Tr, Td } from '@patternfly/react-table';
-import { columnNames } from './PVEditStep';
-import { PersistentVolume } from 'src/types/PersistentVolume';
+import { Button } from '@patternfly/react-core';
+import PencilAltIcon from '@patternfly/react-icons/dist/esm/icons/pencil-alt-icon';
+import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
 import { ValidatedTextInput } from '@konveyor/lib-ui';
+
+import { PersistentVolume } from 'src/types/PersistentVolume';
+import { columnNames } from './PVEditStep';
 import { PVEditRowFormValues, usePVEditRowFormState } from './ImportWizardFormContext';
 
 interface PVEditStepTableRowProps {
@@ -14,20 +19,64 @@ interface PVEditStepTableRowProps {
 export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps> = ({
   pv,
   existingValues,
-  // setEditedValues,
+  setEditedValues,
 }) => {
   const rowForm = usePVEditRowFormState(existingValues);
+
+  const [isEditMode, setIsEditMode] = React.useState(false);
 
   return (
     <Tr key={pv.metadata.name}>
       <Td dataLabel={columnNames.sourcePvcName}>{pv.spec.claimRef.name}</Td>
       <Td dataLabel={columnNames.targetPvcName}>
-        <ValidatedTextInput field={rowForm.fields.targetPvcName} fieldId="target-pvc-name" />
+        {isEditMode ? (
+          <ValidatedTextInput field={rowForm.fields.targetPvcName} fieldId="target-pvc-name" />
+        ) : (
+          existingValues.targetPvcName
+        )}
       </Td>
       <Td dataLabel={columnNames.storageClass}>TODO: Select</Td>
       <Td dataLabel={columnNames.capacity}>TODO: TextInput</Td>
-      <Td dataLabel={columnNames.verifyCopy}></Td>
-      <Td>TODO: edit controls</Td>
+      <Td dataLabel={columnNames.verifyCopy}>TODO</Td>
+      <Td>
+        {!isEditMode ? (
+          <Button
+            variant="link"
+            icon={<PencilAltIcon />}
+            iconPosition="right"
+            onClick={() => setIsEditMode(!isEditMode)}
+          >
+            Edit
+          </Button>
+        ) : (
+          <>
+            <Button
+              variant="link"
+              icon={<CheckIcon />}
+              onClick={() => {
+                // Save edits
+                Object.keys(rowForm.values).forEach((key) =>
+                  rowForm.fields[key].prefill(rowForm.values[key]),
+                );
+                setEditedValues(rowForm.values);
+                setIsEditMode(!isEditMode);
+              }}
+            />
+            <Button
+              variant="plain"
+              icon={<TimesIcon />}
+              onClick={() => {
+                // Cancel edits
+                rowForm.revert();
+                setEditedValues(existingValues);
+                setIsEditMode(!isEditMode);
+              }}
+            >
+              <TimesIcon />
+            </Button>
+          </>
+        )}
+      </Td>
     </Tr>
   );
 };

--- a/src/components/ImportWizard/PVEditStepTableRow.tsx
+++ b/src/components/ImportWizard/PVEditStepTableRow.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { Tr, Td } from '@patternfly/react-table';
-import { Button } from '@patternfly/react-core';
+import { Button, MenuContent, MenuItem, MenuList } from '@patternfly/react-core';
 import PencilAltIcon from '@patternfly/react-icons/dist/esm/icons/pencil-alt-icon';
 import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
 import { ValidatedTextInput } from '@konveyor/lib-ui';
 
 import { PersistentVolume } from 'src/types/PersistentVolume';
+import { SimpleSelectMenu } from 'src/common/components/SimpleSelectMenu';
+import { MOCK_STORAGE_CLASSES } from 'src/mock/StorageClasses.mock';
 import { columnNames } from './PVEditStep';
 import { PVEditRowFormValues, usePVEditRowFormState } from './ImportWizardFormContext';
 
@@ -21,6 +23,9 @@ export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps
   existingValues,
   setEditedValues,
 }) => {
+  // TODO load this from the host cluster via the SDK
+  const storageClasses = MOCK_STORAGE_CLASSES;
+
   const rowForm = usePVEditRowFormState(existingValues);
 
   const [isEditMode, setIsEditMode] = React.useState(false);
@@ -35,10 +40,29 @@ export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps
           existingValues.targetPvcName
         )}
       </Td>
-      <Td dataLabel={columnNames.storageClass}>TODO: Select</Td>
+      <Td dataLabel={columnNames.storageClass}>
+        {isEditMode ? (
+          <SimpleSelectMenu<string>
+            selected={rowForm.values.storageClass}
+            setSelected={rowForm.fields.storageClass.setValue}
+          >
+            <MenuContent>
+              <MenuList>
+                {storageClasses.map((sc) => (
+                  <MenuItem key={sc.metadata.name} itemId={sc.metadata.name}>
+                    {sc.metadata.name}
+                  </MenuItem>
+                ))}
+              </MenuList>
+            </MenuContent>
+          </SimpleSelectMenu>
+        ) : (
+          existingValues.storageClass
+        )}
+      </Td>
       <Td dataLabel={columnNames.capacity}>TODO: TextInput</Td>
       <Td dataLabel={columnNames.verifyCopy}>TODO</Td>
-      <Td>
+      <Td modifier="nowrap">
         {!isEditMode ? (
           <Button
             variant="link"

--- a/src/components/ImportWizard/PVEditStepTableRow.tsx
+++ b/src/components/ImportWizard/PVEditStepTableRow.tsx
@@ -45,6 +45,7 @@ export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps
           <SimpleSelectMenu<string>
             selected={rowForm.values.storageClass}
             setSelected={rowForm.fields.storageClass.setValue}
+            toggleProps={{ style: { width: '100%' } }}
           >
             <MenuContent>
               <MenuList>

--- a/src/components/ImportWizard/PVEditStepTableRow.tsx
+++ b/src/components/ImportWizard/PVEditStepTableRow.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { Tr, Td } from '@patternfly/react-table';
+import { columnNames } from './PVEditStep';
+import { PersistentVolume } from 'src/types/PersistentVolume';
+import { ValidatedTextInput } from '@konveyor/lib-ui';
+import { PVEditRowFormValues, usePVEditRowFormState } from './ImportWizardFormContext';
+
+interface PVEditStepTableRowProps {
+  pv: PersistentVolume;
+  existingValues: PVEditRowFormValues;
+  setEditedValues: (values: PVEditRowFormValues) => void;
+}
+
+export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps> = ({
+  pv,
+  existingValues,
+  // setEditedValues,
+}) => {
+  const rowForm = usePVEditRowFormState(existingValues);
+
+  return (
+    <Tr key={pv.metadata.name}>
+      <Td dataLabel={columnNames.sourcePvcName}>{pv.spec.claimRef.name}</Td>
+      <Td dataLabel={columnNames.targetPvcName}>
+        <ValidatedTextInput field={rowForm.fields.targetPvcName} fieldId="target-pvc-name" />
+      </Td>
+      <Td dataLabel={columnNames.storageClass}>TODO: Select</Td>
+      <Td dataLabel={columnNames.capacity}>TODO: TextInput</Td>
+      <Td dataLabel={columnNames.verifyCopy}></Td>
+      <Td>TODO: edit controls</Td>
+    </Tr>
+  );
+};

--- a/src/components/ImportWizard/PVSelectStep.tsx
+++ b/src/components/ImportWizard/PVSelectStep.tsx
@@ -8,7 +8,7 @@ import { PersistentVolume } from 'src/types/PersistentVolume';
 import { MOCK_PERSISTENT_VOLUMES } from 'src/mock/PersistentVolumes.mock';
 import { isSameResource } from 'src/utils/helpers';
 import { useSortState } from 'src/common/hooks/useSortState';
-import { getDefaultEditValuesForPV, ImportWizardFormContext } from './ImportWizardFormContext';
+import { ImportWizardFormContext } from './ImportWizardFormContext';
 
 export type PVMigrationType = 'fs-copy' | 'ns-copy' | 'move';
 
@@ -23,21 +23,11 @@ export const PVSelectStep: React.FunctionComponent = () => {
 
   // TODO figure out if we need infinite-scroll? Look into how VirtualizedTable works in the SDK / Console?
 
-  const setSelectedPVsAndPrefillEdit = (selectedPVs: PersistentVolume[]) => {
-    form.fields.selectedPVs.setValue(selectedPVs);
-    const defaultValuesByPVName = {};
-    selectedPVs.forEach((pv) => {
-      defaultValuesByPVName[pv.metadata.name] =
-        forms.pvEdit.values.valuesByPVName[pv.metadata.name] || getDefaultEditValuesForPV(pv);
-    });
-    forms.pvEdit.fields.valuesByPVName.setValue(defaultValuesByPVName);
-  };
-
   const { isItemSelected, toggleItemSelected, areAllSelected, selectAll } =
     useSelectionState<PersistentVolume>({
       items: pvs,
       isEqual: (a, b) => isSameResource(a.metadata, b.metadata),
-      externalState: [form.fields.selectedPVs.value, setSelectedPVsAndPrefillEdit],
+      externalState: [form.fields.selectedPVs.value, form.fields.selectedPVs.setValue],
     });
 
   const columnNames = {

--- a/src/components/ImportWizard/PVSelectStep.tsx
+++ b/src/components/ImportWizard/PVSelectStep.tsx
@@ -4,11 +4,11 @@ import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-tab
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { useSelectionState } from '@konveyor/lib-ui';
 
-import { getDefaultEditValuesForPV, ImportWizardFormContext } from './ImportWizardFormContext';
 import { PersistentVolume } from 'src/types/PersistentVolume';
 import { MOCK_PERSISTENT_VOLUMES } from 'src/mock/PersistentVolumes.mock';
 import { isSameResource } from 'src/utils/helpers';
 import { useSortState } from 'src/common/hooks/useSortState';
+import { getDefaultEditValuesForPV, ImportWizardFormContext } from './ImportWizardFormContext';
 
 export type PVMigrationType = 'fs-copy' | 'ns-copy' | 'move';
 

--- a/src/components/TmpCrudTesting.tsx
+++ b/src/components/TmpCrudTesting.tsx
@@ -55,7 +55,6 @@ export const TmpCrudTesting: React.FunctionComponent = () => {
     namespaced: true,
     namespace,
   });
-  console.log('RENDERED!');
   const createPipelineMutation = useCreatePipelineMutation();
   const [newPipelineName, setNewPipelineName] = React.useState('');
   const [isModalOpen, setIsModalOpen] = React.useState(false);

--- a/src/mock/StorageClasses.mock.ts
+++ b/src/mock/StorageClasses.mock.ts
@@ -1,0 +1,43 @@
+import { StorageClass } from 'src/types/StorageClass';
+
+export let MOCK_STORAGE_CLASSES: StorageClass[] = [];
+
+if (process.env.NODE_ENV === 'development' || process.env.DATA_SOURCE === 'mock') {
+  MOCK_STORAGE_CLASSES = [
+    {
+      kind: 'StorageClass',
+      metadata: {
+        name: 'default',
+        namespace: 'openshift-migration',
+      },
+    },
+    {
+      kind: 'StorageClass',
+      metadata: {
+        name: 'mock-storage-1',
+        namespace: 'openshift-migration',
+      },
+    },
+    {
+      kind: 'StorageClass',
+      metadata: {
+        name: 'mock-storage-2',
+        namespace: 'openshift-migration',
+      },
+    },
+    {
+      kind: 'StorageClass',
+      metadata: {
+        name: 'mock-storage-3',
+        namespace: 'openshift-migration',
+      },
+    },
+    {
+      kind: 'StorageClass',
+      metadata: {
+        name: 'mock-storage-4',
+        namespace: 'openshift-migration',
+      },
+    },
+  ];
+}

--- a/src/types/StorageClass.ts
+++ b/src/types/StorageClass.ts
@@ -1,0 +1,12 @@
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+
+// https://kubernetes.io/docs/concepts/storage/storage-classes/
+
+export interface StorageClass extends K8sResourceCommon {
+  kind: 'StorageClass';
+  provisioner?: string;
+  parameters?: {
+    type: string;
+  };
+  reclaimPolicy?: 'Retain' | 'Delete' | string; // TODO can we narrow this?
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,9 +77,9 @@
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
 "@konveyor/lib-ui@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@konveyor/lib-ui/-/lib-ui-6.0.0.tgz#e6063f1ae47ac172242ce764286edc29fd227d1f"
-  integrity sha512-0Za3WU3vbmTHZozIo9JCu/3b8NFO/xYKzJXKaXulfn+U2/WDvGD0ejOgHSg4DtnzgUiY2sz4Gre6CoU1JaEBBg==
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@konveyor/lib-ui/-/lib-ui-6.1.0.tgz#33843ee72ea0e31fa2c6008879adc4bd8bf59229"
+  integrity sha512-pBJfkCFXphZ7WM1ixBgLju1bhzMjKbviFo4mPZd79bVHFl+fipu4rbpZBHysS46pU76rTtzy0fhKgTzRjJ2buA==
   dependencies:
     fast-deep-equal "^3.1.3"
     react-query "^3.26.0"


### PR DESCRIPTION
This PR implements the basics of the Edit PVs step (https://marvelapp.com/prototype/ade2i33/screen/84800488) including a composable implementation of the [Inline Edit pattern](https://www.patternfly.org/v4/components/inline-edit/design-guidelines/#table-inline-edit) in a table (possibly worth contributing a generic version of this as a PF docs example).

Notable changes:
* The ImportWizard now keeps track of which form state objects map to which wizard StepIds and uses this to prevent navigation to steps past the first form with invalid values in the sequence. See `stepIdReached` logic.
* The rows of the table are factored into their own PVEditStepTableRow so that each can have its own instance of `usePVEditRowFormState()`. The return type of this hook is used to derive the type of the Record values `pvEdit.editValuesByPV` field in the main wizard form state (keys are PV names), and the `existingValues` / `setExistingValues` props are used to persist the local state to wizard-level state when confirming edit mode. This is done so that changes can be reverted to the last-confirmed values if the user clicks the cancel icon.
* The state of which rows are in edit mode has been lifted to the wizard level as the `pvEdit.isEditModeByPV` field of the wizard form state (similar to `editValuesByPV`, but the values are just booleans) so that it can be used to block all wizard navigation while a row is being edited. This is done to prevent unintended loss of changes if the user leaves this step without confirming row edits. A custom footer has been added to the wizard to facilitate this. This is stored as a `useFormField` for convenience since the form state is already passed via context, but it could have just been regular React state (it has no validation).
* The SimpleSelectMenu component added in #14 (based on https://www.patternfly.org/v4/demos/composable-menu/#composable-simple-select) is now used for the Storage Class selection. This is a more flexible alternative to the standard Select component we used in forklift-ui via our SimpleSelect abstraction there.
* TS types have been added for StorageClass, and new mock storage classes are added.

Remaining work here:
* We need to figure out what the units will be for the `capacity` field and how we'll manage the suffix there (currently `Gi` is part of the value itself, but this will probably not work).
* The whole step needs to be converted to use PersistentVolumeClaims rather than PersistentVolumes as the top-level resource, which seems better done in a followup PR because this one is getting large.
* We still need filter controls on both tables.