### PR TITLE
Rename/refactor views to use PersistentVolumeClaims instead of PersistentVolumes as the first-class resource

### DIFF
--- a/src/components/ImportWizard/ImportWizard.tsx
+++ b/src/components/ImportWizard/ImportWizard.tsx
@@ -13,8 +13,8 @@ import { IFormState } from '@konveyor/lib-ui';
 import { useNamespaceContext } from 'src/context/NamespaceContext';
 import { SourceClusterProjectStep } from './SourceClusterProjectStep';
 import { SourceProjectDetailsStep } from './SourceProjectDetailsStep';
-import { PVSelectStep } from './PVSelectStep';
-import { PVEditStep } from './PVEditStep';
+import { PVSelectStep } from './PVCSelectStep';
+import { PVEditStep } from './PVCEditStep';
 import { PipelineSettingsStep } from './PipelineSettingsStep';
 import { ReviewStep } from './ReviewStep';
 import { ImportWizardFormContext, useImportWizardFormState } from './ImportWizardFormContext';
@@ -47,7 +47,7 @@ export const ImportWizard: React.FunctionComponent = () => {
   const stepIdReached =
     firstInvalidFormStepId !== undefined ? firstInvalidFormStepId : StepId.Review;
 
-  const somePVRowIsEditMode = Object.values(forms.pvEdit.values.isEditModeByPV).some(
+  const somePVRowIsEditMode = Object.values(forms.pvEdit.values.isEditModeByPVC).some(
     (isEditMode) => isEditMode,
   );
   const allNavDisabled = somePVRowIsEditMode;
@@ -73,8 +73,8 @@ export const ImportWizard: React.FunctionComponent = () => {
   const onMoveToStep: WizardStepFunctionType = (newStep, prevStep) => {
     if (newStep.id === StepId.Review) {
       // TODO generate YAML from forms
-      forms.review.fields.pipelineYaml.prefill('TODO generate yaml here');
-      forms.review.fields.pipelineRunYaml.prefill('TODO generate yaml here');
+      forms.review.fields.pipelineYaml.prefill('TODO generate Pipeline yaml here');
+      forms.review.fields.pipelineRunYaml.prefill('TODO generate PipelineRun yaml here');
     }
   };
 
@@ -101,7 +101,7 @@ export const ImportWizard: React.FunctionComponent = () => {
             ],
           },
           {
-            name: 'Persistent volumes',
+            name: 'Persistent volume claims',
             steps: [
               {
                 id: StepId.PVSelect,

--- a/src/components/ImportWizard/PVCEditStep.tsx
+++ b/src/components/ImportWizard/PVCEditStep.tsx
@@ -5,7 +5,7 @@ import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 import { useSortState } from 'src/common/hooks/useSortState';
 import { ImportWizardFormContext } from './ImportWizardFormContext';
-import { PVEditStepTableRow } from './PVEditStepTableRow';
+import { PVEditStepTableRow } from './PVCEditStepTableRow';
 
 export const columnNames = {
   sourcePvcName: 'Source PVC name',
@@ -18,24 +18,21 @@ export const columnNames = {
 export const PVEditStep: React.FunctionComponent = () => {
   const forms = React.useContext(ImportWizardFormContext);
   const form = forms.pvEdit;
-  const { selectedPVs } = forms.pvSelect.values;
+  const { selectedPVCs } = forms.pvSelect.values;
 
   // TODO filter state -- move to lib-ui and add generics?
-  const { sortBy, onSort, sortedItems } = useSortState(selectedPVs, (pv) => [
-    pv.spec.claimRef.name,
-  ]);
+  const { sortBy, onSort, sortedItems } = useSortState(selectedPVCs, (pvc) => [pvc.metadata.name]);
 
   return (
     <>
       <TextContent className={spacing.mbMd}>
-        <Text component="h2">Edit persistent volumes</Text>
+        <Text component="h2">Edit persistent volume claims</Text>
         <Text component="p">
-          Change properties of persistent volumes when copied to the target project. Also, select
-          whether the copy should be verified on the target.
+          Change properties of persistent volume claims when copied to the target project. Also,
+          select whether the copy should be verified on the target.
         </Text>
       </TextContent>
       {/* TODO FilterToolbar -- do we want to actually move it to lib-ui now? */}
-      {/* TODO do we need to remove the border on the bottom of the header row as in the mockups? */}
       <Form>
         <TableComposable borders={false} variant="compact">
           <Thead>
@@ -49,22 +46,22 @@ export const PVEditStep: React.FunctionComponent = () => {
             </Tr>
           </Thead>
           <Tbody>
-            {sortedItems.map((pv) => (
+            {sortedItems.map((pvc) => (
               <PVEditStepTableRow
-                key={pv.metadata.name}
-                pv={pv}
-                existingValues={form.values.editValuesByPV[pv.metadata.name]}
+                key={pvc.metadata.name}
+                pvc={pvc}
+                existingValues={form.values.editValuesByPVC[pvc.metadata.name]}
                 setEditedValues={(newValues) => {
-                  form.fields.editValuesByPV.setValue((oldValues) => ({
+                  form.fields.editValuesByPVC.setValue((oldValues) => ({
                     ...oldValues,
-                    [pv.metadata.name]: newValues,
+                    [pvc.metadata.name]: newValues,
                   }));
                 }}
-                isEditMode={form.values.isEditModeByPV[pv.metadata.name]}
+                isEditMode={form.values.isEditModeByPVC[pvc.metadata.name]}
                 setIsEditMode={(isEditMode) => {
-                  form.fields.isEditModeByPV.setValue((oldValues) => ({
+                  form.fields.isEditModeByPVC.setValue((oldValues) => ({
                     ...oldValues,
-                    [pv.metadata.name]: isEditMode,
+                    [pvc.metadata.name]: isEditMode,
                   }));
                 }}
               />

--- a/src/components/ImportWizard/PVCEditStepTableRow.tsx
+++ b/src/components/ImportWizard/PVCEditStepTableRow.tsx
@@ -6,14 +6,14 @@ import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
 import { ValidatedTextInput } from '@konveyor/lib-ui';
 
-import { PersistentVolume } from 'src/types/PersistentVolume';
+import { PersistentVolumeClaim } from 'src/types/PersistentVolume';
 import { SimpleSelectMenu } from 'src/common/components/SimpleSelectMenu';
 import { MOCK_STORAGE_CLASSES } from 'src/mock/StorageClasses.mock';
-import { columnNames } from './PVEditStep';
+import { columnNames } from './PVCEditStep';
 import { PVEditRowFormValues, usePVEditRowFormState } from './ImportWizardFormContext';
 
 interface PVEditStepTableRowProps {
-  pv: PersistentVolume;
+  pvc: PersistentVolumeClaim;
   existingValues: PVEditRowFormValues;
   setEditedValues: (values: PVEditRowFormValues) => void;
   isEditMode: boolean;
@@ -21,7 +21,7 @@ interface PVEditStepTableRowProps {
 }
 
 export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps> = ({
-  pv,
+  pvc,
   existingValues,
   setEditedValues,
   isEditMode,
@@ -33,13 +33,13 @@ export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps
   const rowForm = usePVEditRowFormState(existingValues);
 
   return (
-    <Tr key={pv.metadata.name}>
-      <Td dataLabel={columnNames.sourcePvcName}>{pv.spec.claimRef.name}</Td>
+    <Tr key={pvc.metadata.name}>
+      <Td dataLabel={columnNames.sourcePvcName}>{pvc.metadata.name}</Td>
       <Td dataLabel={columnNames.targetPvcName}>
         {isEditMode ? (
           <ValidatedTextInput
             field={rowForm.fields.targetPvcName}
-            fieldId={`target-pvc-name-${pv.spec.claimRef.name}`}
+            fieldId={`target-pvc-name-${pvc.metadata.name}`}
           />
         ) : (
           existingValues.targetPvcName
@@ -51,7 +51,7 @@ export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps
             selected={rowForm.values.storageClass}
             setSelected={rowForm.fields.storageClass.setValue}
             toggleProps={{ style: { width: '100%' } }}
-            id={`storage-class-select-${pv.spec.claimRef.name}`}
+            id={`storage-class-select-${pvc.metadata.name}`}
           >
             <MenuContent>
               <MenuList>
@@ -71,7 +71,7 @@ export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps
         {isEditMode ? (
           <ValidatedTextInput
             field={rowForm.fields.capacity}
-            fieldId={`capacity-${pv.spec.claimRef.name}`}
+            fieldId={`capacity-${pvc.metadata.name}`}
           />
         ) : (
           existingValues.capacity
@@ -79,11 +79,11 @@ export const PVEditStepTableRow: React.FunctionComponent<PVEditStepTableRowProps
       </Td>
       <Td dataLabel={columnNames.verifyCopy} textCenter>
         <Checkbox
-          aria-label={`Verify copy for PVC ${pv.spec.claimRef.name}`}
+          aria-label={`Verify copy for PVC ${pvc.metadata.name}`}
           isDisabled={!isEditMode}
           isChecked={rowForm.values.verifyCopy}
           onChange={rowForm.fields.verifyCopy.setValue}
-          id={`verify-copy-${pv.spec.claimRef.name}`}
+          id={`verify-copy-${pvc.metadata.name}`}
         />
       </Td>
       <Td modifier="nowrap">

--- a/src/mock/PersistentVolumes.mock.ts
+++ b/src/mock/PersistentVolumes.mock.ts
@@ -1,38 +1,59 @@
-import { PersistentVolume } from 'src/types/PersistentVolume';
+import { PersistentVolume, PersistentVolumeClaim } from 'src/types/PersistentVolume';
 
 export let MOCK_PERSISTENT_VOLUMES: PersistentVolume[] = [];
+export let MOCK_PERSISTENT_VOLUME_CLAIMS: PersistentVolumeClaim[] = [];
 
 if (process.env.NODE_ENV === 'development' || process.env.DATA_SOURCE === 'mock') {
   const mockPV = (nameSuffix: string): PersistentVolume => ({
     kind: 'PersistentVolume',
     metadata: {
-      name: `pv_${nameSuffix}`,
+      name: `pv-${nameSuffix}`,
       namespace: 'openshift-migration',
     },
     spec: {
-      // TODO
-      accessModes: ['ReadWriteMany'], // TODO
       capacity: {
         storage: '100Gi',
       },
+      volumeMode: 'Filesystem',
+      accessModes: ['ReadWriteMany'],
+      persistentVolumeReclaimPolicy: 'Retain',
+      storageClassName: 'mock-storage-1',
       claimRef: {
-        name: `pvc_${nameSuffix}`,
+        name: `pvc-${nameSuffix}`,
         namespace: 'openshift-migration',
       },
-      persistentVolumeReclaimPolicy: 'foo',
-      storageClassName: 'mock-storage-class',
-      volumeMode: 'Filesystem', // TODO
     },
     status: {
       phase: 'Bound',
     },
   });
 
-  MOCK_PERSISTENT_VOLUMES = [
-    mockPV('123456789 1'),
-    mockPV('123456789 2'),
-    mockPV('123456789 3'),
-    mockPV('123456789 4'),
-    mockPV('123456789 5'),
-  ];
+  const mockPVC = (nameSuffix: string): PersistentVolumeClaim => ({
+    kind: 'PersistentVolumeClaim',
+    metadata: {
+      name: `pvc-${nameSuffix}`,
+      namespace: 'openshift-migration',
+    },
+    spec: {
+      volumeMode: 'Filesystem',
+      accessModes: ['ReadWriteMany'],
+      resources: {
+        requests: {
+          storage: '100Gi',
+        },
+      },
+      storageClassName: 'mock-storage-1',
+    },
+    status: {
+      accessModes: ['ReadWriteMany'],
+      capacity: {
+        storage: '100Gi',
+      },
+      phase: 'Bound',
+    },
+  });
+
+  const nameSuffixes = ['123456789-1', '123456789-2', '123456789-3', '123456789-4', '123456789-5'];
+  MOCK_PERSISTENT_VOLUMES = nameSuffixes.map(mockPV);
+  MOCK_PERSISTENT_VOLUME_CLAIMS = nameSuffixes.map(mockPVC);
 }

--- a/src/types/PersistentVolume.ts
+++ b/src/types/PersistentVolume.ts
@@ -54,10 +54,10 @@ export interface PersistentVolumeClaim extends K8sResourceCommon {
     };
   };
   status?: {
-    accessModes: AccessMode[];
-    capacity: {
+    accessModes?: AccessMode[];
+    capacity?: {
       storage: string; // e.g. '100Gi' - Binary SI (Ki, Mi, Gi, Pi, Ti) or Decimal SI (k, M, G, P, T) format
     };
-    phase: PVPhase;
+    phase?: PVPhase;
   };
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,5 @@
 import { ObjectReference } from '@openshift-console/dynamic-plugin-sdk';
+import { PersistentVolumeClaim } from 'src/types/PersistentVolume';
 
 export const isSameResource = (
   refA: ObjectReference | null | undefined,
@@ -13,3 +14,6 @@ export const isSameResource = (
       refB.namespace &&
       refA.name === refB.name &&
       refA.namespace === refB.namespace));
+
+export const getCapacity = (pvc: PersistentVolumeClaim) =>
+  pvc.status?.capacity?.storage || pvc.spec.resources.requests.storage;


### PR DESCRIPTION
Also improves the TS types for both PVs and PVCs based on k8s docs, and adds mock data for PVCs.

Keeping this refactor in its own PR so it doesn't make other changes harder to read.