### PR TITLE
Add basic filtering by name on the tables using plugin SDK ListPageFilter

### DIFF
--- a/src/components/ImportWizard/PVCEditStep.tsx
+++ b/src/components/ImportWizard/PVCEditStep.tsx
@@ -2,8 +2,14 @@ import * as React from 'react';
 import { TextContent, Text, Form } from '@patternfly/react-core';
 import { TableComposable, Thead, Tr, Th, Tbody } from '@patternfly/react-table';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import {
+  ListPageFilter,
+  RowFilter,
+  useListPageFilter,
+} from '@openshift-console/dynamic-plugin-sdk';
 
 import { useSortState } from 'src/common/hooks/useSortState';
+import { PersistentVolumeClaim } from 'src/types/PersistentVolume';
 import { ImportWizardFormContext } from './ImportWizardFormContext';
 import { PVCEditStepTableRow } from './PVCEditStepTableRow';
 
@@ -20,8 +26,9 @@ export const PVCEditStep: React.FunctionComponent = () => {
   const form = forms.pvcEdit;
   const { selectedPVCs } = forms.pvcSelect.values;
 
-  // TODO filter state -- move to lib-ui and add generics?
-  const { sortBy, onSort, sortedItems } = useSortState(selectedPVCs, (pvc) => [pvc.metadata.name]);
+  const rowFilters: RowFilter<PersistentVolumeClaim>[] = []; // TODO do we need to add one here for storage classes, by the available ones in the source?
+  const [data, filteredData, onFilterChange] = useListPageFilter(selectedPVCs, rowFilters);
+  const { sortBy, onSort, sortedItems } = useSortState(filteredData, (pvc) => [pvc.metadata.name]);
 
   return (
     <>
@@ -32,7 +39,13 @@ export const PVCEditStep: React.FunctionComponent = () => {
           select whether the copy should be verified on the target.
         </Text>
       </TextContent>
-      {/* TODO FilterToolbar -- do we want to actually move it to lib-ui now? */}
+      <ListPageFilter
+        data={data}
+        loaded // TODO do we use this while loading or not render this at all while loading?
+        rowFilters={rowFilters}
+        onFilterChange={onFilterChange}
+        hideLabelFilter
+      />
       <Form>
         <TableComposable borders={false} variant="compact">
           <Thead>

--- a/src/mock/PersistentVolumes.mock.ts
+++ b/src/mock/PersistentVolumes.mock.ts
@@ -53,7 +53,7 @@ if (process.env.NODE_ENV === 'development' || process.env.DATA_SOURCE === 'mock'
     },
   });
 
-  const nameSuffixes = ['123456789-1', '123456789-2', '123456789-3', '123456789-4', '123456789-5'];
+  const nameSuffixes = ['foo', 'bar', 'baz', '123456789-4', '123456789-5'];
   MOCK_PERSISTENT_VOLUMES = nameSuffixes.map(mockPV);
   MOCK_PERSISTENT_VOLUME_CLAIMS = nameSuffixes.map(mockPVC);
 }


### PR DESCRIPTION
Adds a simple filter bar for searching PVCs by name. We can add additional filters for e.g. storage class later, those will be a little more complex (the ListPageFilter provided by the plugin SDK isn't documented so I'm just seeing what I can learn by reading its usages elsewhere in the OpenShift Console). I figure we should wait until we have real data wired up from the proxy service for that.