### PR TITLE
Handle wizard submit for stateless applications (generate destination API secret, generate editable Pipeline and PipelineRun YAML, create resources and navigate to Tekton UI)

### DIFF
--- a/src/api/pipelineHelpers.ts
+++ b/src/api/pipelineHelpers.ts
@@ -2,10 +2,16 @@ import { ImportWizardFormState } from 'src/components/ImportWizard/ImportWizardF
 import { PipelineKind, PipelineRunKind } from './types/pipelines-plugin';
 import { OAuthSecret } from './types/Secret';
 
+export interface WizardTektonResources {
+  pipeline: PipelineKind;
+  pipelineRun: PipelineRunKind;
+}
+
 export const formsToTektonResources = (
   forms: ImportWizardFormState,
-  destinationApiSecret: OAuthSecret, // TODO when do we create this? how do we keep it updated if the user changes the URL in the first step?
-): { pipeline: PipelineKind; pipelineRun: PipelineRunKind } => {
+  destinationApiSecret: OAuthSecret,
+  namespace: string,
+): WizardTektonResources => {
   const { sourceNamespace, sourceApiSecret } = forms.sourceClusterProject.values;
   // const { selectedPVCs } = forms.pvcSelect.values;
   // const { editValuesByPVC } = forms.pvcEdit.values;
@@ -19,6 +25,7 @@ export const formsToTektonResources = (
     kind: 'Pipeline',
     metadata: {
       name: pipelineName, // <--
+      namespace, // <--
     },
     spec: {
       params: [
@@ -232,6 +239,7 @@ export const formsToTektonResources = (
     kind: 'PipelineRun',
     metadata: {
       generateName: `${pipelineName}-`, // <--
+      namespace, // <--
     },
     spec: {
       ...(!startImmediately ? { status: 'PipelineRunPending' } : {}), // <--

--- a/src/api/pipelineHelpers.ts
+++ b/src/api/pipelineHelpers.ts
@@ -1,0 +1,282 @@
+import { ImportWizardFormState } from 'src/components/ImportWizard/ImportWizardFormContext';
+import { PipelineKind, PipelineRunKind } from './types/pipelines-plugin';
+import { OAuthSecret } from './types/Secret';
+
+export const formsToTektonResources = (
+  forms: ImportWizardFormState,
+  destinationApiSecret: OAuthSecret, // TODO when do we create this? how do we keep it updated if the user changes the URL in the first step?
+): { pipeline: PipelineKind; pipelineRun: PipelineRunKind } => {
+  const { sourceNamespace, sourceApiSecret } = forms.sourceClusterProject.values;
+  // const { selectedPVCs } = forms.pvcSelect.values;
+  // const { editValuesByPVC } = forms.pvcEdit.values;
+  const { pipelineName, startImmediately } = forms.pipelineSettings.values;
+
+  // TODO these resources are only for stateless applications, dropped in 1-to-1 from that section of User Stories in https://github.com/konveyor/enhancements/pull/59.
+  // TODO we'll need to make this more dynamic to support all user stories in there, either via logic in this helper or by breaking the stories into individual helpers.
+
+  const pipeline: PipelineKind = {
+    apiVersion: 'tekton.dev/v1beta1',
+    kind: 'Pipeline',
+    metadata: {
+      name: pipelineName, // <--
+    },
+    spec: {
+      params: [
+        {
+          name: 'source-cluster-secret',
+          type: 'string',
+        },
+        {
+          name: 'source-namespace',
+          type: 'string',
+        },
+        {
+          name: 'destination-cluster-secret',
+          type: 'string',
+        },
+        {
+          name: 'optional-flags',
+          type: 'string',
+        },
+      ],
+      workspaces: [
+        {
+          name: 'shared-data',
+        },
+        {
+          name: 'kubeconfig',
+        },
+      ],
+      tasks: [
+        {
+          name: 'generate-source-kubeconfig',
+          params: [
+            {
+              name: 'cluster-secret',
+              value: '$(params.source-cluster-secret)',
+            },
+            {
+              name: 'context-name',
+              value: 'source',
+            },
+          ],
+          taskRef: {
+            name: 'crane-kubeconfig-generator',
+            kind: 'ClusterTask',
+          },
+          workspaces: [
+            {
+              name: 'kubeconfig',
+              workspace: 'kubeconfig',
+            },
+          ],
+        },
+        {
+          name: 'generate-destination-kubeconfig',
+          params: [
+            {
+              name: 'cluster-secret',
+              value: '$(params.source-cluster-secret)',
+            },
+            {
+              name: 'context-name',
+              value: 'destination',
+            },
+          ],
+          taskRef: {
+            name: 'crane-kubeconfig-generator',
+            kind: 'ClusterTask',
+          },
+          workspaces: [
+            {
+              name: 'kubeconfig',
+              workspace: 'kubeconfig',
+            },
+          ],
+        },
+        {
+          name: 'export',
+          runAfter: ['generate-source-kubeconfig', 'generate-destination-kubeconfig'],
+          params: [
+            {
+              name: 'context',
+              value: 'source',
+            },
+            {
+              name: 'namespace',
+              value: '$(params.source-namespace)',
+            },
+          ],
+          taskRef: {
+            name: 'crane-export',
+            kind: 'ClusterTask',
+          },
+          workspaces: [
+            {
+              name: 'export',
+              workspace: 'shared-data',
+              subPath: 'export',
+            },
+            {
+              name: 'kubeconfig',
+              workspace: 'kubeconfig',
+            },
+          ],
+        },
+        {
+          name: 'transform',
+          runAfter: ['export'],
+          params: [
+            {
+              name: 'optional-flags',
+              value: '$(params.optional-flags)',
+            },
+          ],
+          taskRef: {
+            name: 'crane-transform',
+            kind: 'ClusterTask',
+          },
+          workspaces: [
+            {
+              name: 'export',
+              workspace: 'shared-data',
+              subPath: 'export',
+            },
+            {
+              name: 'transform',
+              workspace: 'shared-data',
+              subPath: 'transform',
+            },
+          ],
+        },
+        {
+          name: 'apply',
+          runAfter: ['transform'],
+          taskRef: {
+            name: 'crane-apply',
+            kind: 'ClusterTask',
+          },
+          workspaces: [
+            {
+              name: 'export',
+              workspace: 'shared-data',
+              subPath: 'export',
+            },
+            {
+              name: 'transform',
+              workspace: 'shared-data',
+              subPath: 'transform',
+            },
+            {
+              name: 'apply',
+              workspace: 'shared-data',
+              subPath: 'apply',
+            },
+          ],
+        },
+        {
+          name: 'kustomize-init',
+          runAfter: ['apply'],
+          params: [
+            {
+              name: 'source-namespace',
+              value: '$(params.source-namespace)',
+            },
+            {
+              name: 'namespace',
+              value: '$(context.taskRun.namespace)',
+            },
+          ],
+          taskRef: {
+            name: 'crane-kustomize-init',
+            kind: 'ClusterTask',
+          },
+          workspaces: [
+            {
+              name: 'apply',
+              workspace: 'shared-data',
+              subPath: 'apply',
+            },
+            {
+              name: 'kustomize',
+              workspace: 'shared-data',
+            },
+          ],
+        },
+        {
+          name: 'kubectl-apply-kustomize',
+          runAfter: ['kustomize-init'],
+          params: [
+            {
+              name: 'context',
+              value: 'destination',
+            },
+          ],
+          taskRef: {
+            name: 'kubectl-apply-kustomize',
+            kind: 'ClusterTask',
+          },
+          workspaces: [
+            {
+              name: 'kustomize',
+              workspace: 'shared-data',
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  const pipelineRun: PipelineRunKind = {
+    apiVersion: 'tekton.dev/v1beta1',
+    kind: 'PipelineRun',
+    metadata: {
+      generateName: `${pipelineName}-`, // <--
+    },
+    spec: {
+      ...(!startImmediately ? { status: 'PipelineRunPending' } : {}), // <--
+      params: [
+        {
+          name: 'source-cluster-secret',
+          value: sourceApiSecret.metadata.name, // <--
+        },
+        {
+          name: 'destination-cluster-secret',
+          value: destinationApiSecret.metadata.name, // <--
+        },
+        {
+          name: 'source-namespace',
+          value: sourceNamespace, // <--
+        },
+        {
+          name: 'optional-flags',
+          value: '',
+        },
+      ],
+      workspaces: [
+        {
+          name: 'shared-data',
+          volumeClaimTemplate: {
+            spec: {
+              accessModes: ['ReadWriteOnce'],
+              resources: {
+                requests: {
+                  storage: '10Mi',
+                },
+              },
+            },
+          },
+        },
+        {
+          name: 'kubeconfig',
+          emptyDir: {},
+        },
+      ],
+      pipelineRef: {
+        name: pipelineName,
+      },
+    },
+  };
+
+  return { pipeline, pipelineRun };
+};

--- a/src/api/queries/pipelines.ts
+++ b/src/api/queries/pipelines.ts
@@ -1,11 +1,28 @@
-import { K8sGroupVersionKind, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  k8sCreate,
+  K8sGroupVersionKind,
+  k8sPatch,
+  useK8sModel,
+  useK8sWatchResource,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { useMutation } from 'react-query';
 import { useNamespaceContext } from 'src/context/NamespaceContext';
+import { getObjectRef } from 'src/utils/helpers';
+import { WizardTektonResources } from '../pipelineHelpers';
 import { PipelineKind } from '../types/pipelines-plugin';
+import { OAuthSecret } from '../types/Secret';
+import { secretGVK } from './secrets';
 
-const pipelineGVK: K8sGroupVersionKind = {
+export const pipelineGVK: K8sGroupVersionKind = {
   group: 'tekton.dev',
   version: 'v1beta1',
   kind: 'Pipeline',
+};
+
+export const pipelineRunGVK: K8sGroupVersionKind = {
+  group: 'tekton.dev',
+  version: 'v1beta1',
+  kind: 'PipelineRun',
 };
 
 export const useWatchPipelines = () => {
@@ -17,4 +34,44 @@ export const useWatchPipelines = () => {
     namespace,
   });
   return { data, loaded, error };
+};
+
+interface CreateTektonResourcesParams {
+  resources: WizardTektonResources;
+  secrets: OAuthSecret[];
+}
+export const useCreateTektonResourcesMutation = (
+  onSuccess: (resources: WizardTektonResources) => void,
+) => {
+  const [pipelineModel] = useK8sModel(pipelineGVK);
+  const [pipelineRunModel] = useK8sModel(pipelineRunGVK);
+  const [secretModel] = useK8sModel(secretGVK);
+  return useMutation<WizardTektonResources, Error, CreateTektonResourcesParams>(
+    async ({ resources, secrets }) => {
+      const pipeline = await k8sCreate({
+        model: pipelineModel,
+        data: resources.pipeline,
+      });
+      const pipelineRun = await k8sCreate({
+        model: pipelineRunModel,
+        data: resources.pipelineRun,
+      });
+      const pipelineRef = getObjectRef(pipeline);
+      await Promise.all(
+        secrets.map((secret) =>
+          k8sPatch({
+            model: secretModel,
+            resource: secret,
+            data: [
+              !secret.metadata.ownerReferences
+                ? { op: 'add', path: '/metadata/ownerReferences', value: [pipelineRef] }
+                : { op: 'add', path: '/metadata/ownerReferences/-', value: pipelineRef },
+            ],
+          }),
+        ),
+      );
+      return { pipeline, pipelineRun };
+    },
+    { onSuccess },
+  );
 };

--- a/src/api/queries/pipelines.ts
+++ b/src/api/queries/pipelines.ts
@@ -1,0 +1,20 @@
+import { K8sGroupVersionKind, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { useNamespaceContext } from 'src/context/NamespaceContext';
+import { PipelineKind } from '../types/pipelines-plugin';
+
+const pipelineGVK: K8sGroupVersionKind = {
+  group: 'tekton.dev',
+  version: 'v1beta1',
+  kind: 'Pipeline',
+};
+
+export const useWatchPipelines = () => {
+  const namespace = useNamespaceContext();
+  const [data, loaded, error] = useK8sWatchResource<PipelineKind[]>({
+    groupVersionKind: pipelineGVK,
+    isList: true,
+    namespaced: true,
+    namespace,
+  });
+  return { data, loaded, error };
+};

--- a/src/api/queries/secrets.ts
+++ b/src/api/queries/secrets.ts
@@ -14,8 +14,8 @@ import { isSameResource } from 'src/utils/helpers';
 import { ProxyConfigMap, ProxyConfigMapCluster } from '../types/ConfigMap';
 import { OAuthSecret, Secret } from '../types/Secret';
 
-const secretGVK: K8sGroupVersionKind = { group: '', version: 'v1', kind: 'Secret' };
-const configMapGVK: K8sGroupVersionKind = { group: '', version: 'v1', kind: 'ConfigMap' };
+export const secretGVK: K8sGroupVersionKind = { group: '', version: 'v1', kind: 'Secret' };
+export const configMapGVK: K8sGroupVersionKind = { group: '', version: 'v1', kind: 'ConfigMap' };
 
 interface UseConfigureSecretMutationArgs {
   existingSecretFromState: OAuthSecret | null;

--- a/src/api/queries/secrets.ts
+++ b/src/api/queries/secrets.ts
@@ -7,6 +7,7 @@ import {
   k8sPatch,
   k8sDelete,
 } from '@openshift-console/dynamic-plugin-sdk';
+import { K8sModel } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
 import { useMutation } from 'react-query';
 import { useNamespaceContext } from 'src/context/NamespaceContext';
 import { isSameResource } from 'src/utils/helpers';
@@ -16,7 +17,7 @@ import { OAuthSecret, Secret } from '../types/Secret';
 const secretGVK: K8sGroupVersionKind = { group: '', version: 'v1', kind: 'Secret' };
 const configMapGVK: K8sGroupVersionKind = { group: '', version: 'v1', kind: 'ConfigMap' };
 
-interface UseConfigureProxyMutationArgs {
+interface UseConfigureSecretMutationArgs {
   existingSecretFromState: OAuthSecret | null;
   onSuccess: (newSecret: OAuthSecret) => void;
 }
@@ -28,7 +29,7 @@ interface ConfigureProxyMutationParams {
 export const useConfigureProxyMutation = ({
   existingSecretFromState,
   onSuccess,
-}: UseConfigureProxyMutationArgs) => {
+}: UseConfigureSecretMutationArgs) => {
   const [secretModel] = useK8sModel(secretGVK);
   const [configMapModel] = useK8sModel(configMapGVK);
   const namespace = useNamespaceContext();
@@ -38,17 +39,7 @@ export const useConfigureProxyMutation = ({
       let existingSecret = existingSecretFromState;
       if (!existingSecret) {
         // See if we have an existing secret for this cluster URL that isn't associated with a pipeline.
-        const nsSecrets = await k8sList<Secret>({
-          model: secretModel,
-          queryParams: { ns: namespace },
-        });
-        existingSecret = nsSecrets.find(
-          (secret) =>
-            secret.metadata.annotations?.['konveyor.io/crane-ui-plugin'] ===
-              'source-cluster-oauth' &&
-            (secret.metadata.ownerReferences || []).length === 0 &&
-            secret.data.url === btoa(apiUrl),
-        ) as OAuthSecret | undefined;
+        existingSecret = await findExistingSecret(secretModel, namespace, apiUrl, 'source');
       }
 
       let secretToUse: OAuthSecret | null = null;
@@ -90,14 +81,66 @@ export const useConfigureProxyMutation = ({
 
       return secretToUse;
     },
-    {
-      onSuccess,
-    },
+    { onSuccess },
   );
 };
 
+interface ConfigureDestinationSecretParams {
+  token: string;
+}
+
+export const useConfigureDestinationSecretMutation = ({
+  existingSecretFromState,
+  onSuccess,
+}: UseConfigureSecretMutationArgs) => {
+  const [secretModel] = useK8sModel(secretGVK);
+  const namespace = useNamespaceContext();
+  const apiUrl = 'https://kubernetes.default.svc';
+  return useMutation<OAuthSecret, Error, ConfigureDestinationSecretParams>(
+    async ({ token }) => {
+      // If we have a secret in state, use that instead of looking for one to update.
+      let existingSecret = existingSecretFromState;
+      if (!existingSecret) {
+        // See if we have an existing secret for this cluster URL that isn't associated with a pipeline.
+        existingSecret = await findExistingSecret(secretModel, namespace, apiUrl, 'destination');
+      }
+      const updatedSecret = existingSecret
+        ? await k8sPatch({
+            model: secretModel,
+            resource: existingSecret,
+            data: [{ op: 'replace', path: '/data/token', value: btoa(token) }],
+          })
+        : await k8sCreate({
+            model: secretModel,
+            data: getNewSecret('destination', namespace, apiUrl, token),
+          });
+      return updatedSecret;
+    },
+    { onSuccess },
+  );
+};
+
+const findExistingSecret = async (
+  secretModel: K8sModel,
+  namespace: string,
+  apiUrl: string,
+  sourceOrDestination: 'source' | 'destination',
+) => {
+  const nsSecrets = await k8sList<Secret>({
+    model: secretModel,
+    queryParams: { ns: namespace },
+  });
+  return nsSecrets.find(
+    (secret) =>
+      secret.metadata.annotations?.['konveyor.io/crane-ui-plugin'] ===
+        `${sourceOrDestination}-cluster-oauth` &&
+      (secret.metadata.ownerReferences || []).length === 0 &&
+      secret.data.url === btoa(apiUrl),
+  ) as OAuthSecret | undefined;
+};
+
 const getNewSecret = (
-  sourceOrTarget: 'source' | 'target',
+  sourceOrDestination: 'source' | 'destination',
   namespace: string,
   apiUrl: string,
   token: string,
@@ -105,10 +148,10 @@ const getNewSecret = (
   apiVersion: 'v1',
   kind: 'Secret',
   metadata: {
-    generateName: `${sourceOrTarget}-cluster-`,
+    generateName: `${sourceOrDestination}-cluster-`,
     namespace,
     annotations: {
-      'konveyor.io/crane-ui-plugin': `${sourceOrTarget}-cluster-oauth`,
+      'konveyor.io/crane-ui-plugin': `${sourceOrDestination}-cluster-oauth`,
     },
   },
   data: {

--- a/src/api/queries/sourceResources.ts
+++ b/src/api/queries/sourceResources.ts
@@ -17,16 +17,16 @@ export const useSourceNamespacesQuery = (sourceApiSecret?: OAuthSecret, isEnable
 
 interface UseSourceNamespacedQueryArgs {
   sourceApiSecret?: OAuthSecret;
-  namespace: string;
+  sourceNamespace: string;
 }
 
 const useSourceNamespacedListQuery = <T extends K8sResourceCommon>(
-  { sourceApiSecret, namespace }: UseSourceNamespacedQueryArgs,
+  { sourceApiSecret, sourceNamespace }: UseSourceNamespacedQueryArgs,
   kindPlural: string,
 ) => {
   const client = useProxyK8sClient(sourceApiSecret);
-  const resource = new CoreNamespacedResource(kindPlural, namespace);
-  return useQuery([kindPlural, sourceApiSecret?.metadata.name, namespace], {
+  const resource = new CoreNamespacedResource(kindPlural, sourceNamespace);
+  return useQuery([kindPlural, sourceApiSecret?.metadata.name, sourceNamespace], {
     queryFn: () => client.list<T>(resource),
     enabled: !!sourceApiSecret,
     refetchInterval: 15_000,

--- a/src/api/types/Secret.ts
+++ b/src/api/types/Secret.ts
@@ -20,7 +20,7 @@ export interface Secret extends K8sResourceCommon {
 export interface OAuthSecret extends Secret {
   metadata: ObjectMetadata & {
     annotations: ObjectMetadata['annotations'] & {
-      'konveyor.io/crane-ui-plugin'?: 'source-cluster-oauth' | 'target-cluster-oauth';
+      'konveyor.io/crane-ui-plugin'?: 'source-cluster-oauth' | 'destination-cluster-oauth';
     };
   };
   data: {

--- a/src/api/types/pipelines-plugin/README.md
+++ b/src/api/types/pipelines-plugin/README.md
@@ -6,7 +6,10 @@ This directory has been lifted entirely from the Pipelines plugin source in the 
 
 It was copied on Feb 15, 2022 from version `3348a3b`. The last changes in that directory at that time were from Dec 23, 2021.
 
-The only changes here since copying these were in commit `071d562`, to change internal imports to use the `@openshift-console/dynamic-plugin-sdk` package and to disable/satisfy certain eslint rules.
+The only changes here since copying these were:
+
+- Commit `071d562` changed internal imports to use the `@openshift-console/dynamic-plugin-sdk` package and disabled/satisfied certain eslint rules.
+- Shortly after, some missing fields were added that are specifically called out in comments.
 
 ## We should remove these some day.
 

--- a/src/api/types/pipelines-plugin/README.md
+++ b/src/api/types/pipelines-plugin/README.md
@@ -1,0 +1,11 @@
+# TypeScript types for Tekton resources
+
+## NOTE: This code was copied from [openshift/console](https://github.com/openshift/console/).
+
+This directory has been lifted entirely from the Pipelines plugin source in the OpenShift Console UI repository at [console/frontend/packages/pipelines-plugin/src/types](https://github.com/openshift/console/tree/3348a3bd2fa852a9592ddeb79fd7735b06e875bd/frontend/packages/pipelines-plugin/src/types).
+
+It was copied on Feb 15, 2022 from version `3348a3b`. The last changes in that directory at that time were from Dec 23, 2021.
+
+The only modifications here are to change internal imports to use the `@openshift-console/dynamic-plugin-sdk` package instead.
+
+**Eventually it would be great to find a way to deduplicate this code and import these types from the pipelines plugin source directly somehow.** Until then we'll need to make sure this remains up to date if there are breaking changes.

--- a/src/api/types/pipelines-plugin/README.md
+++ b/src/api/types/pipelines-plugin/README.md
@@ -6,6 +6,8 @@ This directory has been lifted entirely from the Pipelines plugin source in the 
 
 It was copied on Feb 15, 2022 from version `3348a3b`. The last changes in that directory at that time were from Dec 23, 2021.
 
-The only modifications here are to change internal imports to use the `@openshift-console/dynamic-plugin-sdk` package instead.
+The only changes here since copying these were in commit `071d562`, to change internal imports to use the `@openshift-console/dynamic-plugin-sdk` package and to disable/satisfy certain eslint rules.
 
-**Eventually it would be great to find a way to deduplicate this code and import these types from the pipelines plugin source directly somehow.** Until then we'll need to make sure this remains up to date if there are breaking changes.
+## We should remove these some day.
+
+Eventually it would be great to find a way to deduplicate this code and import these types from the pipelines plugin source directly somehow. Until then we'll need to make sure this remains up to date if there are breaking changes.

--- a/src/api/types/pipelines-plugin/coreTekton.ts
+++ b/src/api/types/pipelines-plugin/coreTekton.ts
@@ -1,0 +1,59 @@
+export type ResourceTarget = 'inputs' | 'outputs';
+
+export type TektonParam = {
+  default?: string | string[];
+  description?: string;
+  name: string;
+  type?: 'string' | 'array';
+};
+
+export type TektonTaskSteps = {
+  // TODO: Figure out required fields
+  name: string;
+  args?: string[];
+  command?: string[];
+  image?: string;
+  resources?: {}[] | {};
+  env?: { name: string; value: string }[];
+  script?: string[];
+};
+
+export type TaskResult = {
+  name: string;
+  description?: string;
+};
+
+export type TektonTaskSpec = {
+  metadata?: {};
+  description?: string;
+  steps: TektonTaskSteps[];
+  params?: TektonParam[];
+  resources?: TektonResourceGroup<TektonResource>;
+  results?: TaskResult[];
+  workspaces?: TektonWorkspace[];
+};
+
+export type TektonResourceGroup<ResourceType> = {
+  inputs?: ResourceType[];
+  outputs?: ResourceType[];
+};
+
+/** Deprecated upstream - Workspaces are replacing Resources */
+export type TektonResource = {
+  name: string;
+  optional?: boolean;
+  type: string; // TODO: limit to known strings
+};
+
+export type TektonWorkspace = {
+  name: string;
+  description?: string;
+  mountPath?: string;
+  readOnly?: boolean;
+  optional?: boolean;
+};
+
+export type TektonResultsRun = {
+  name: string;
+  value: string;
+};

--- a/src/api/types/pipelines-plugin/coreTekton.ts
+++ b/src/api/types/pipelines-plugin/coreTekton.ts
@@ -1,3 +1,6 @@
+// NOTE: This code was copied from the OpenShift console source. See ./README.md for details.
+/* eslint-disable @typescript-eslint/ban-types */
+
 export type ResourceTarget = 'inputs' | 'outputs';
 
 export type TektonParam = {
@@ -8,7 +11,7 @@ export type TektonParam = {
 };
 
 export type TektonTaskSteps = {
-  // TODO: Figure out required fields
+  // TODO: Figure out required fields (NOTE: this TODO is from original console code, see ./README.md)
   name: string;
   args?: string[];
   command?: string[];
@@ -24,6 +27,7 @@ export type TaskResult = {
 };
 
 export type TektonTaskSpec = {
+  // eslint-disable-next-line @typescript-eslint/ban-types
   metadata?: {};
   description?: string;
   steps: TektonTaskSteps[];
@@ -42,7 +46,7 @@ export type TektonResourceGroup<ResourceType> = {
 export type TektonResource = {
   name: string;
   optional?: boolean;
-  type: string; // TODO: limit to known strings
+  type: string; // TODO: limit to known strings (NOTE: this TODO is from original console code, see ./README.md)
 };
 
 export type TektonWorkspace = {

--- a/src/api/types/pipelines-plugin/index.ts
+++ b/src/api/types/pipelines-plugin/index.ts
@@ -1,0 +1,6 @@
+export * from './coreTekton';
+export * from './pipeline';
+export * from './pipelineRun';
+export * from './pipelineResource';
+export * from './task';
+export * from './taskRun';

--- a/src/api/types/pipelines-plugin/pipeline.ts
+++ b/src/api/types/pipelines-plugin/pipeline.ts
@@ -1,0 +1,67 @@
+import { K8sResourceCommon } from '@console/internal/module/k8s';
+import {
+  TektonParam,
+  TektonResource,
+  TektonResourceGroup,
+  TektonTaskSpec,
+  TektonWorkspace,
+} from './coreTekton';
+
+export type PipelineTaskRef = {
+  kind?: string;
+  name: string;
+};
+
+export type PipelineTaskWorkspace = {
+  name: string;
+  workspace: string;
+  optional?: boolean;
+};
+
+export type PipelineTaskResource = {
+  name: string;
+  resource?: string;
+  from?: string[];
+};
+
+export type PipelineTaskParam = {
+  name: string;
+  value: any;
+};
+
+export type WhenExpression = {
+  input: string;
+  operator: string;
+  values: string[];
+};
+
+export type PipelineResult = {
+  name: string;
+  value: string;
+  description?: string;
+};
+
+export type PipelineTask = {
+  name: string;
+  params?: PipelineTaskParam[];
+  resources?: TektonResourceGroup<PipelineTaskResource>;
+  runAfter?: string[];
+  taskRef?: PipelineTaskRef;
+  taskSpec?: TektonTaskSpec;
+  when?: WhenExpression[];
+  workspaces?: PipelineTaskWorkspace[];
+};
+
+export type PipelineSpec = {
+  params?: TektonParam[];
+  resources?: TektonResource[];
+  serviceAccountName?: string;
+  tasks: PipelineTask[];
+  workspaces?: TektonWorkspace[];
+  finally?: PipelineTask[];
+  results?: PipelineResult[];
+};
+
+export type PipelineKind = K8sResourceCommon & {
+  spec: PipelineSpec;
+};

--- a/src/api/types/pipelines-plugin/pipeline.ts
+++ b/src/api/types/pipelines-plugin/pipeline.ts
@@ -1,4 +1,6 @@
-import { K8sResourceCommon } from '@console/internal/module/k8s';
+// NOTE: This code was copied from the OpenShift console source. See ./README.md for details.
+
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import {
   TektonParam,
   TektonResource,
@@ -26,7 +28,7 @@ export type PipelineTaskResource = {
 
 export type PipelineTaskParam = {
   name: string;
-  value: any;
+  value: unknown;
 };
 
 export type WhenExpression = {

--- a/src/api/types/pipelines-plugin/pipeline.ts
+++ b/src/api/types/pipelines-plugin/pipeline.ts
@@ -18,6 +18,7 @@ export type PipelineTaskWorkspace = {
   name: string;
   workspace: string;
   optional?: boolean;
+  subPath?: string; // NOTE: This was added since copying from Console.
 };
 
 export type PipelineTaskResource = {

--- a/src/api/types/pipelines-plugin/pipelineResource.ts
+++ b/src/api/types/pipelines-plugin/pipelineResource.ts
@@ -1,4 +1,6 @@
-import { K8sResourceCommon } from '@console/internal/module/k8s';
+// NOTE: This code was copied from the OpenShift console source. See ./README.md for details.
+
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 export type PipelineResourceKind = K8sResourceCommon & {
   spec: {

--- a/src/api/types/pipelines-plugin/pipelineResource.ts
+++ b/src/api/types/pipelines-plugin/pipelineResource.ts
@@ -1,0 +1,8 @@
+import { K8sResourceCommon } from '@console/internal/module/k8s';
+
+export type PipelineResourceKind = K8sResourceCommon & {
+  spec: {
+    params: { name: string; value: string }[];
+    type: string;
+  };
+};

--- a/src/api/types/pipelines-plugin/pipelineRun.ts
+++ b/src/api/types/pipelines-plugin/pipelineRun.ts
@@ -1,0 +1,159 @@
+import { K8sResourceCommon, ObjectMetadata } from '@console/internal/module/k8s';
+import { TektonResultsRun, TektonTaskSpec } from './coreTekton';
+import { PipelineKind, PipelineSpec } from './pipeline';
+
+export type PLRTaskRunStep = {
+  container: string;
+  imageID?: string;
+  name: string;
+  waiting?: {
+    reason: string;
+  };
+  running?: {
+    startedAt: string;
+  };
+  terminated?: {
+    containerID: string;
+    exitCode: number;
+    finishedAt: string;
+    reason: string;
+    startedAt: string;
+    message?: string;
+  };
+};
+
+export type PLRTaskRunData = {
+  pipelineTaskName: string;
+  status: {
+    completionTime?: string;
+    conditions: Condition[];
+    /** Can be empty */
+    podName: string;
+    startTime: string;
+    steps?: PLRTaskRunStep[];
+    taskSpec?: TektonTaskSpec;
+    taskResults?: { name: string; value: string }[];
+  };
+};
+
+export type PLRTaskRuns = {
+  [taskRunName: string]: PLRTaskRunData;
+};
+
+export type VolumeTypeSecret = {
+  secretName: string;
+  items?: {
+    key: string;
+    path: string;
+  }[];
+};
+
+export type VolumeTypeConfigMaps = {
+  name: string;
+  items?: {
+    key: string;
+    path: string;
+  }[];
+};
+
+export type VolumeTypePVC = {
+  claimName: string;
+};
+
+export type PersistentVolumeClaimType = {
+  persistentVolumeClaim: VolumeTypePVC;
+};
+
+export type VolumeClaimTemplateType = {
+  volumeClaimTemplate: VolumeTypeClaim;
+};
+export type VolumeTypeClaim = {
+  metadata?: ObjectMetadata;
+  spec: {
+    accessModes: string[];
+    resources: {
+      requests: {
+        storage: string;
+      };
+    };
+    storageClassName?: string;
+    volumeMode?: string;
+  };
+};
+
+export type Condition = {
+  type: string;
+  status: string;
+  reason?: string;
+  message?: string;
+  lastTransitionTime?: string;
+};
+
+export type PipelineRunEmbeddedResourceParam = { name: string; value: string };
+export type PipelineRunEmbeddedResource = {
+  name: string;
+  resourceSpec: {
+    params: PipelineRunEmbeddedResourceParam[];
+    type: string;
+  };
+};
+export type PipelineRunReferenceResource = {
+  name: string;
+  resourceRef: {
+    name: string;
+  };
+};
+export type PipelineRunResource = PipelineRunReferenceResource | PipelineRunEmbeddedResource;
+
+export type PipelineRunWorkspace = {
+  name: string;
+  [volumeType: string]:
+    | VolumeTypeSecret
+    | VolumeTypeConfigMaps
+    | VolumeTypePVC
+    | VolumeTypeClaim
+    | {};
+};
+
+export type PipelineRunParam = {
+  name: string;
+  value: string | string[];
+
+  // TODO: To be validated
+  input?: string;
+  output?: string;
+  resource?: object;
+};
+
+export type PipelineRunStatus = {
+  succeededCondition?: string;
+  creationTimestamp?: string;
+  conditions?: Condition[];
+  startTime?: string;
+  completionTime?: string;
+  taskRuns?: PLRTaskRuns;
+  pipelineSpec: PipelineSpec;
+  skippedTasks?: {
+    name: string;
+  }[];
+  pipelineResults?: TektonResultsRun[];
+};
+
+export type PipelineRunKind = K8sResourceCommon & {
+  spec: {
+    pipelineRef?: { name: string };
+    pipelineSpec?: PipelineSpec;
+    params?: PipelineRunParam[];
+    workspaces?: PipelineRunWorkspace[];
+    resources?: PipelineRunResource[];
+    serviceAccountName?: string;
+    timeout?: string;
+    // Only used in a single case - cancelling a pipeline; should not be copied between PLRs
+    status?: 'PipelineRunCancelled' | 'PipelineRunPending';
+  };
+  status?: PipelineRunStatus;
+};
+
+export type PipelineWithLatest = PipelineKind & {
+  latestRun?: PipelineRunKind;
+};

--- a/src/api/types/pipelines-plugin/pipelineRun.ts
+++ b/src/api/types/pipelines-plugin/pipelineRun.ts
@@ -1,4 +1,7 @@
-import { K8sResourceCommon, ObjectMetadata } from '@console/internal/module/k8s';
+// NOTE: This code was copied from the OpenShift console source. See ./README.md for details.
+/* eslint-disable @typescript-eslint/ban-types */
+
+import { K8sResourceCommon, ObjectMetadata } from '@openshift-console/dynamic-plugin-sdk';
 import { TektonResultsRun, TektonTaskSpec } from './coreTekton';
 import { PipelineKind, PipelineSpec } from './pipeline';
 

--- a/src/api/types/pipelines-plugin/task.ts
+++ b/src/api/types/pipelines-plugin/task.ts
@@ -1,4 +1,6 @@
-import { K8sResourceCommon } from '@console/internal/module/k8s';
+// NOTE: This code was copied from the OpenShift console source. See ./README.md for details.
+
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { TektonTaskSpec } from './coreTekton';
 
 export type TaskKind = K8sResourceCommon & {

--- a/src/api/types/pipelines-plugin/task.ts
+++ b/src/api/types/pipelines-plugin/task.ts
@@ -1,0 +1,6 @@
+import { K8sResourceCommon } from '@console/internal/module/k8s';
+import { TektonTaskSpec } from './coreTekton';
+
+export type TaskKind = K8sResourceCommon & {
+  spec: TektonTaskSpec;
+};

--- a/src/api/types/pipelines-plugin/taskRun.ts
+++ b/src/api/types/pipelines-plugin/taskRun.ts
@@ -1,0 +1,42 @@
+import { K8sResourceCommon, PersistentVolumeClaimKind } from '@console/internal/module/k8s';
+import { TektonResource, TektonResultsRun, TektonTaskSpec } from './coreTekton';
+import { PipelineTaskParam, PipelineTaskRef } from './pipeline';
+import {
+  Condition,
+  PLRTaskRunStep,
+  VolumeTypeConfigMaps,
+  VolumeTypePVC,
+  VolumeTypeSecret,
+} from './pipelineRun';
+
+export type TaskRunWorkspace = {
+  name: string;
+  volumeClaimTemplate?: PersistentVolumeClaimKind;
+  persistentVolumeClaim?: VolumeTypePVC;
+  configMap?: VolumeTypeConfigMaps;
+  emptyDir?: {};
+  secret?: VolumeTypeSecret;
+  subPath?: string;
+};
+
+export type TaskRunStatus = {
+  completionTime?: string;
+  conditions?: Condition[];
+  podName?: string;
+  startTime?: string;
+  steps?: PLRTaskRunStep[];
+  taskResults?: TektonResultsRun[];
+};
+
+export type TaskRunKind = K8sResourceCommon & {
+  spec: {
+    taskRef?: PipelineTaskRef;
+    taskSpec?: TektonTaskSpec;
+    serviceAccountName?: string;
+    params?: PipelineTaskParam[];
+    resources?: TektonResource[];
+    timeout?: string;
+    workspaces?: TaskRunWorkspace[];
+  };
+  status?: TaskRunStatus;
+};

--- a/src/api/types/pipelines-plugin/taskRun.ts
+++ b/src/api/types/pipelines-plugin/taskRun.ts
@@ -1,6 +1,12 @@
-import { K8sResourceCommon, PersistentVolumeClaimKind } from '@console/internal/module/k8s';
+// NOTE: This code was copied from the OpenShift console source. See ./README.md for details.
+/* eslint-disable @typescript-eslint/ban-types */
+
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { TektonResource, TektonResultsRun, TektonTaskSpec } from './coreTekton';
 import { PipelineTaskParam, PipelineTaskRef } from './pipeline';
+
+import { PersistentVolumeClaim } from 'src/api/types/PersistentVolume';
+
 import {
   Condition,
   PLRTaskRunStep,
@@ -11,7 +17,7 @@ import {
 
 export type TaskRunWorkspace = {
   name: string;
-  volumeClaimTemplate?: PersistentVolumeClaimKind;
+  volumeClaimTemplate?: PersistentVolumeClaim;
   persistentVolumeClaim?: VolumeTypePVC;
   configMap?: VolumeTypeConfigMaps;
   emptyDir?: {};

--- a/src/api/types/pipelines-plugin/tektonHub.ts
+++ b/src/api/types/pipelines-plugin/tektonHub.ts
@@ -1,3 +1,5 @@
+// NOTE: This code was copied from the OpenShift console source. See ./README.md for details.
+
 export type TektonHubItem = {
   id: number;
   name: string;

--- a/src/api/types/pipelines-plugin/tektonHub.ts
+++ b/src/api/types/pipelines-plugin/tektonHub.ts
@@ -1,0 +1,39 @@
+export type TektonHubItem = {
+  id: number;
+  name: string;
+};
+
+export type TektonHubCategory = TektonHubItem;
+
+export type TektonHubTag = TektonHubItem;
+
+export type TektonHubPlatform = TektonHubItem;
+
+export type TektonHubCatalog = TektonHubItem & {
+  type: string;
+};
+
+export type TektonHubLatestVersion = {
+  id: number;
+  version: string;
+  displayName: string;
+  description: string;
+  minPipelinesVersion: string;
+  rawURL: string;
+  webURL: string;
+  hubURL: string;
+  platforms: TektonHubPlatform[];
+  updatedAt: string;
+};
+
+export type TektonHubTask = {
+  id: number;
+  name: string;
+  categories: TektonHubCategory[];
+  catalog: TektonHubCatalog;
+  platforms: TektonHubPlatform[];
+  kind: string;
+  latestVersion: TektonHubLatestVersion;
+  tags: TektonHubTag[];
+  rating: number;
+};

--- a/src/common/schema.ts
+++ b/src/common/schema.ts
@@ -1,6 +1,7 @@
 import * as yup from 'yup';
 import * as yaml from 'js-yaml';
 import { useSourceNamespacesQuery } from 'src/api/queries/sourceResources';
+import { useWatchPipelines } from 'src/api/queries/pipelines';
 
 export const dnsLabelNameSchema = yup
   .string()
@@ -57,3 +58,16 @@ export const yamlSchema = yup.string().test({
     return true;
   },
 });
+
+export const getPipelineNameSchema = (pipelinesWatch: ReturnType<typeof useWatchPipelines>) =>
+  dnsLabelNameSchema
+    .label('Pipeline name')
+    .required()
+    .max(57) // So it can be used as the generateName for a PipelineRun, which will add 6 characters
+    .test(
+      'unique-name',
+      'A pipeline with this name already exists',
+      (value) =>
+        !pipelinesWatch.loaded ||
+        !pipelinesWatch.data?.find((pipeline) => pipeline.metadata.name === value),
+    );

--- a/src/components/ImportWizard/ImportWizard.tsx
+++ b/src/components/ImportWizard/ImportWizard.tsx
@@ -9,7 +9,7 @@ import {
   WizardStepFunctionType,
 } from '@patternfly/react-core';
 import wizardStyles from '@patternfly/react-styles/css/components/Wizard/wizard';
-import { IFormState } from '@konveyor/lib-ui';
+import { IFormState, ResolvedQuery } from '@konveyor/lib-ui';
 
 import { useNamespaceContext } from 'src/context/NamespaceContext';
 import { SourceClusterProjectStep } from './SourceClusterProjectStep';
@@ -161,7 +161,12 @@ export const ImportWizard: React.FunctionComponent = () => {
             id: StepId.Review,
             name: 'Review',
             component: (
-              <ReviewStep configureDestinationSecretMutation={configureDestinationSecretMutation} />
+              <ResolvedQuery
+                result={configureDestinationSecretMutation}
+                errorTitle="Cannot configure destination cluster secret"
+              >
+                <ReviewStep />
+              </ResolvedQuery>
             ),
             canJumpTo: canMoveToStep(StepId.Review),
           },

--- a/src/components/ImportWizard/ImportWizardFormContext.tsx
+++ b/src/components/ImportWizard/ImportWizardFormContext.tsx
@@ -39,8 +39,8 @@ export const useImportWizardFormState = () => {
       return true;
     });
 
-  const apiUrlField = useFormField<string>('', credentialsFieldSchema.label('Cluster API URL'));
-  const tokenField = useFormField<string>('', credentialsFieldSchema.label('OAuth token'));
+  const apiUrlField = useFormField('', credentialsFieldSchema.label('Cluster API URL'));
+  const tokenField = useFormField('', credentialsFieldSchema.label('OAuth token'));
 
   const sourceNamespacesQuery = useSourceNamespacesQuery(sourceApiSecretField.value);
   const credentialsAreValid = areSourceCredentialsValid(
@@ -87,13 +87,14 @@ export const useImportWizardFormState = () => {
       {
         apiUrl: apiUrlField,
         token: tokenField,
-        namespace: useFormField(
+        sourceNamespace: useFormField(
           '',
           getSourceNamespaceSchema(sourceNamespacesQuery, credentialsAreValid).label(
             'Project name',
           ),
         ),
         sourceApiSecret: sourceApiSecretField,
+        destinationApiUrl: useFormField('', yup.string().required()),
       },
       {
         revalidateOnChange: [credentialsAreValid],
@@ -109,7 +110,7 @@ export const useImportWizardFormState = () => {
       editValuesByPVC: editValuesByPVCField,
     }),
     pipelineSettings: useFormState({
-      pipelineName: useFormField('', dnsLabelNameSchema.label('Pipeline name').required()), // TODO check if it exists (use list or single lookup?)
+      pipelineName: useFormField('', dnsLabelNameSchema.label('Pipeline name').required()), // TODO check if it exists (use list or single lookup?) -- also make sure it is short enough for a generateName on the pipelineRun
       startImmediately: useFormField(false, yup.boolean().required()),
     }),
     review: useFormState({

--- a/src/components/ImportWizard/ImportWizardFormContext.tsx
+++ b/src/components/ImportWizard/ImportWizardFormContext.tsx
@@ -85,11 +85,6 @@ export const useImportWizardFormState = () => {
   };
 
   return {
-    meta: {
-      // Form-related state that isn't attached to particular fields and doesn't need validation goes here
-      destinationApiSecret: React.useState<OAuthSecret | null>(null),
-      // TODO move sourceApiSecret and isEditModeByPVC here?
-    },
     sourceClusterProject: useFormState(
       {
         apiUrl: apiUrlField,
@@ -124,6 +119,7 @@ export const useImportWizardFormState = () => {
       startImmediately: useFormField(false, yup.boolean().required()),
     }),
     review: useFormState({
+      destinationApiSecret: useFormField<OAuthSecret | null>(null, yup.mixed()),
       pipelineYaml: useFormField('', yamlSchema.label('Pipeline').required()),
       pipelineRunYaml: useFormField('', yamlSchema.label('PipelineRun').required()),
     }),

--- a/src/components/ImportWizard/ReviewStep.tsx
+++ b/src/components/ImportWizard/ReviewStep.tsx
@@ -17,15 +17,18 @@ import flex from '@patternfly/react-styles/css/layouts/Flex/flex';
 import { SimpleSelectMenu } from 'src/common/components/SimpleSelectMenu';
 import { ImportWizardFormContext, ImportWizardFormState } from './ImportWizardFormContext';
 
-type ReviewStepFieldKey = keyof ImportWizardFormState['review']['fields'];
+type YamlFieldKey = keyof Pick<
+  ImportWizardFormState['review']['fields'],
+  'pipelineYaml' | 'pipelineRunYaml'
+>;
+const YAML_FIELD_KEYS: YamlFieldKey[] = ['pipelineYaml', 'pipelineRunYaml'];
 
 export const ReviewStep: React.FunctionComponent = () => {
   const forms = React.useContext(ImportWizardFormContext);
 
   // TODO warn somehow if the user is going to override their manual edits here when they go to another step (use isTouched)? not sure how to do that if they use canJumpTo
 
-  const [selectedEditorKey, setSelectedEditorKey] =
-    React.useState<ReviewStepFieldKey>('pipelineYaml');
+  const [selectedEditorKey, setSelectedEditorKey] = React.useState<YamlFieldKey>('pipelineYaml');
   const selectedEditorFormField = forms.review.fields[selectedEditorKey];
 
   const editorContainerRef = React.useRef<HTMLDivElement>(null);
@@ -45,10 +48,12 @@ export const ReviewStep: React.FunctionComponent = () => {
     <Flex direction={{ default: 'column' }} style={{ height: '100%' }}>
       <TextContent className={spacing.mbMd}>
         <Text component="h2">Review</Text>
-        <Text component="p">Review the YAML for the OpenShift pipeline that will be created.</Text>
+        <Text component="p">
+          Review the YAML for the OpenShift Pipeline and PipelineRun that will be created.
+        </Text>
       </TextContent>
       <FlexItem>
-        <SimpleSelectMenu<ReviewStepFieldKey>
+        <SimpleSelectMenu<YamlFieldKey>
           selected={selectedEditorKey}
           setSelected={setSelectedEditorKey}
           selectedLabel={selectedEditorFormField.schema.describe().label}
@@ -57,9 +62,9 @@ export const ReviewStep: React.FunctionComponent = () => {
         >
           <MenuContent>
             <MenuList>
-              {Object.entries(forms.review.fields).map(([fieldKey, field]) => (
+              {YAML_FIELD_KEYS.map((fieldKey) => (
                 <MenuItem key={fieldKey} itemId={fieldKey}>
-                  {field.schema.describe().label}
+                  {forms.review.fields[fieldKey].schema.describe().label}
                 </MenuItem>
               ))}
             </MenuList>

--- a/src/components/ImportWizard/ReviewStep.tsx
+++ b/src/components/ImportWizard/ReviewStep.tsx
@@ -16,17 +16,10 @@ import flex from '@patternfly/react-styles/css/layouts/Flex/flex';
 
 import { SimpleSelectMenu } from 'src/common/components/SimpleSelectMenu';
 import { ImportWizardFormContext, ImportWizardFormState } from './ImportWizardFormContext';
-import { useConfigureDestinationSecretMutation } from 'src/api/queries/secrets';
-import { ResolvedQuery } from '@konveyor/lib-ui';
 
 type ReviewStepFieldKey = keyof ImportWizardFormState['review']['fields'];
 
-interface ReviewStepProps {
-  configureDestinationSecretMutation: ReturnType<typeof useConfigureDestinationSecretMutation>;
-}
-export const ReviewStep: React.FunctionComponent<ReviewStepProps> = ({
-  configureDestinationSecretMutation,
-}) => {
+export const ReviewStep: React.FunctionComponent = () => {
   const forms = React.useContext(ImportWizardFormContext);
 
   // TODO warn somehow if the user is going to override their manual edits here when they go to another step (use isTouched)? not sure how to do that if they use canJumpTo
@@ -43,66 +36,56 @@ export const ReviewStep: React.FunctionComponent<ReviewStepProps> = ({
     forms.review.fields.pipelineRunYaml.error?.message,
   ].filter((err) => !!err);
 
-  // TODO on smaller screen sizes this flex layout turns into columns, we need a better fix for the editor height
+  // TODO on smaller screen sizes and when errors show, this flex layout turns into columns, we need a better fix for the editor height
   // TODO take a look at onEditorDidMount in the PF examples, what's going on with that, how is it implemented?
   // https://www.patternfly.org/v4/components/code-editor/
+  // TODO figure out what's going wrong when we try to set up monaco-editor-webpack-plugin, which we need for syntax highlighting
 
   return (
-    <ResolvedQuery
-      result={configureDestinationSecretMutation}
-      errorTitle="Cannot configure destination cluster secret"
-    >
-      <Flex direction={{ default: 'column' }} style={{ height: '100%' }}>
-        <TextContent className={spacing.mbMd}>
-          <Text component="h2">Review</Text>
-          <Text component="p">
-            Review the YAML for the OpenShift pipeline that will be created.
-          </Text>
-        </TextContent>
-        <FlexItem>
-          <SimpleSelectMenu<ReviewStepFieldKey>
-            selected={selectedEditorKey}
-            setSelected={setSelectedEditorKey}
-            selectedLabel={selectedEditorFormField.schema.describe().label}
-            id="editor-select"
-            toggleProps={{ style: { width: '150px' } }}
-          >
-            <MenuContent>
-              <MenuList>
-                {Object.entries(forms.review.fields).map(([fieldKey, field]) => (
-                  <MenuItem key={fieldKey} itemId={fieldKey}>
-                    {field.schema.describe().label}
-                  </MenuItem>
-                ))}
-              </MenuList>
-            </MenuContent>
-          </SimpleSelectMenu>
-        </FlexItem>
-        <div
-          className={flex.modifiers.grow}
-          style={{ overflow: 'hidden' }}
-          ref={editorContainerRef}
+    <Flex direction={{ default: 'column' }} style={{ height: '100%' }}>
+      <TextContent className={spacing.mbMd}>
+        <Text component="h2">Review</Text>
+        <Text component="p">Review the YAML for the OpenShift pipeline that will be created.</Text>
+      </TextContent>
+      <FlexItem>
+        <SimpleSelectMenu<ReviewStepFieldKey>
+          selected={selectedEditorKey}
+          setSelected={setSelectedEditorKey}
+          selectedLabel={selectedEditorFormField.schema.describe().label}
+          id="editor-select"
+          toggleProps={{ style: { width: '150px' } }}
         >
-          <CodeEditor
-            key={selectedEditorKey}
-            isDarkTheme
-            isLineNumbersVisible
-            isLanguageLabelVisible
-            isMinimapVisible
-            code={selectedEditorFormField.value}
-            onChange={selectedEditorFormField.setValue}
-            language={Language.yaml}
-            height={`${editorContainerHeight - 60}px`}
-          />
-        </div>
-        {yamlErrors.length > 0 ? (
-          <Alert isInline variant="danger" title="Invalid YAML">
-            {yamlErrors.map((error) => (
-              <div key={error}>{error}</div>
-            ))}
-          </Alert>
-        ) : null}
-      </Flex>
-    </ResolvedQuery>
+          <MenuContent>
+            <MenuList>
+              {Object.entries(forms.review.fields).map(([fieldKey, field]) => (
+                <MenuItem key={fieldKey} itemId={fieldKey}>
+                  {field.schema.describe().label}
+                </MenuItem>
+              ))}
+            </MenuList>
+          </MenuContent>
+        </SimpleSelectMenu>
+      </FlexItem>
+      <div className={flex.modifiers.grow} style={{ overflow: 'hidden' }} ref={editorContainerRef}>
+        <CodeEditor
+          key={selectedEditorKey}
+          isDarkTheme
+          isLineNumbersVisible
+          isLanguageLabelVisible
+          isMinimapVisible
+          code={selectedEditorFormField.value}
+          onChange={selectedEditorFormField.setValue}
+          language={Language.yaml}
+          height={`${editorContainerHeight - 60}px`}
+        />
+      </div>
+      {yamlErrors.length > 0 ? (
+        <Alert isInline variant="danger" title="Invalid YAML">
+          {yamlErrors.map((error) => (
+            <div key={error}>{error}</div>
+          ))}
+        </Alert>
+      ) : null}
+    </Flex>
   );
 };

--- a/src/components/ImportWizard/ReviewStep.tsx
+++ b/src/components/ImportWizard/ReviewStep.tsx
@@ -16,10 +16,17 @@ import flex from '@patternfly/react-styles/css/layouts/Flex/flex';
 
 import { SimpleSelectMenu } from 'src/common/components/SimpleSelectMenu';
 import { ImportWizardFormContext, ImportWizardFormState } from './ImportWizardFormContext';
+import { useConfigureDestinationSecretMutation } from 'src/api/queries/secrets';
+import { ResolvedQuery } from '@konveyor/lib-ui';
 
 type ReviewStepFieldKey = keyof ImportWizardFormState['review']['fields'];
 
-export const ReviewStep: React.FunctionComponent = () => {
+interface ReviewStepProps {
+  configureDestinationSecretMutation: ReturnType<typeof useConfigureDestinationSecretMutation>;
+}
+export const ReviewStep: React.FunctionComponent<ReviewStepProps> = ({
+  configureDestinationSecretMutation,
+}) => {
   const forms = React.useContext(ImportWizardFormContext);
 
   // TODO warn somehow if the user is going to override their manual edits here when they go to another step (use isTouched)? not sure how to do that if they use canJumpTo
@@ -36,51 +43,66 @@ export const ReviewStep: React.FunctionComponent = () => {
     forms.review.fields.pipelineRunYaml.error?.message,
   ].filter((err) => !!err);
 
+  // TODO on smaller screen sizes this flex layout turns into columns, we need a better fix for the editor height
+  // TODO take a look at onEditorDidMount in the PF examples, what's going on with that, how is it implemented?
+  // https://www.patternfly.org/v4/components/code-editor/
+
   return (
-    <Flex direction={{ default: 'column' }} style={{ height: '100%' }}>
-      <TextContent className={spacing.mbMd}>
-        <Text component="h2">Review</Text>
-        <Text component="p">Review the YAML for the OpenShift pipeline that will be created.</Text>
-      </TextContent>
-      <FlexItem>
-        <SimpleSelectMenu<ReviewStepFieldKey>
-          selected={selectedEditorKey}
-          setSelected={setSelectedEditorKey}
-          selectedLabel={selectedEditorFormField.schema.describe().label}
-          id="editor-select"
-          toggleProps={{ style: { width: '150px' } }}
+    <ResolvedQuery
+      result={configureDestinationSecretMutation}
+      errorTitle="Cannot configure destination cluster secret"
+    >
+      <Flex direction={{ default: 'column' }} style={{ height: '100%' }}>
+        <TextContent className={spacing.mbMd}>
+          <Text component="h2">Review</Text>
+          <Text component="p">
+            Review the YAML for the OpenShift pipeline that will be created.
+          </Text>
+        </TextContent>
+        <FlexItem>
+          <SimpleSelectMenu<ReviewStepFieldKey>
+            selected={selectedEditorKey}
+            setSelected={setSelectedEditorKey}
+            selectedLabel={selectedEditorFormField.schema.describe().label}
+            id="editor-select"
+            toggleProps={{ style: { width: '150px' } }}
+          >
+            <MenuContent>
+              <MenuList>
+                {Object.entries(forms.review.fields).map(([fieldKey, field]) => (
+                  <MenuItem key={fieldKey} itemId={fieldKey}>
+                    {field.schema.describe().label}
+                  </MenuItem>
+                ))}
+              </MenuList>
+            </MenuContent>
+          </SimpleSelectMenu>
+        </FlexItem>
+        <div
+          className={flex.modifiers.grow}
+          style={{ overflow: 'hidden' }}
+          ref={editorContainerRef}
         >
-          <MenuContent>
-            <MenuList>
-              {Object.entries(forms.review.fields).map(([fieldKey, field]) => (
-                <MenuItem key={fieldKey} itemId={fieldKey}>
-                  {field.schema.describe().label}
-                </MenuItem>
-              ))}
-            </MenuList>
-          </MenuContent>
-        </SimpleSelectMenu>
-      </FlexItem>
-      <div className={flex.modifiers.grow} style={{ overflow: 'hidden' }} ref={editorContainerRef}>
-        <CodeEditor
-          key={selectedEditorKey}
-          isDarkTheme
-          isLineNumbersVisible
-          isLanguageLabelVisible
-          isMinimapVisible
-          code={selectedEditorFormField.value}
-          onChange={selectedEditorFormField.setValue}
-          language={Language.yaml}
-          height={`${editorContainerHeight - 60}px`}
-        />
-      </div>
-      {yamlErrors.length > 0 ? (
-        <Alert isInline variant="danger" title="Invalid YAML">
-          {yamlErrors.map((error) => (
-            <div key={error}>{error}</div>
-          ))}
-        </Alert>
-      ) : null}
-    </Flex>
+          <CodeEditor
+            key={selectedEditorKey}
+            isDarkTheme
+            isLineNumbersVisible
+            isLanguageLabelVisible
+            isMinimapVisible
+            code={selectedEditorFormField.value}
+            onChange={selectedEditorFormField.setValue}
+            language={Language.yaml}
+            height={`${editorContainerHeight - 60}px`}
+          />
+        </div>
+        {yamlErrors.length > 0 ? (
+          <Alert isInline variant="danger" title="Invalid YAML">
+            {yamlErrors.map((error) => (
+              <div key={error}>{error}</div>
+            ))}
+          </Alert>
+        ) : null}
+      </Flex>
+    </ResolvedQuery>
   );
 };

--- a/src/components/ImportWizard/SourceClusterProjectStep.tsx
+++ b/src/components/ImportWizard/SourceClusterProjectStep.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { TextContent, Text, Form, TextInputProps, FormGroupProps } from '@patternfly/react-core';
+import {
+  TextContent,
+  Text,
+  Form,
+  TextInputProps,
+  FormGroupProps,
+  Popover,
+  Button,
+} from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { ResolvedQueries, ValidatedPasswordInput, ValidatedTextInput } from '@konveyor/lib-ui';
 
@@ -8,6 +16,7 @@ import { useConfigureProxyMutation } from 'src/api/queries/secrets';
 import { OAuthSecret } from 'src/api/types/Secret';
 import { useSourceNamespacesQuery } from 'src/api/queries/sourceResources';
 import { areSourceCredentialsValid } from 'src/api/proxyHelpers';
+import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 
 export const SourceClusterProjectStep: React.FunctionComponent = () => {
   const form = React.useContext(ImportWizardFormContext).sourceClusterProject;
@@ -79,6 +88,39 @@ export const SourceClusterProjectStep: React.FunctionComponent = () => {
           isRequired
           fieldId="project-name"
           greenWhenValid
+        />
+        <ValidatedPasswordInput
+          field={form.fields.destinationToken}
+          isRequired
+          fieldId="destination-token"
+          formGroupProps={{
+            labelIcon: (
+              <Popover
+                bodyContent={
+                  <>
+                    This field is not final and is necessary for the alpha version only (hopefully).
+                    <br />
+                    It is the OAuth token for the destination cluster (this cluster). You can find
+                    it by clicking your username in the top right corner of the screen and choosing
+                    &quot;Copy login command&quot;, then &quot;Display token&quot;.
+                  </>
+                }
+                maxWidth="30vw"
+              >
+                <Button
+                  variant="plain"
+                  aria-label={`More info for ${
+                    form.fields.destinationToken.schema.describe().label
+                  } field`}
+                  onClick={(e) => e.preventDefault()}
+                  aria-describedby="destination-token-info"
+                  className="pf-c-form__group-label-help"
+                >
+                  <HelpIcon noVerticalAlign />
+                </Button>
+              </Popover>
+            ),
+          }}
         />
         <ResolvedQueries
           spinnerMode="none"

--- a/src/components/ImportWizard/SourceClusterProjectStep.tsx
+++ b/src/components/ImportWizard/SourceClusterProjectStep.tsx
@@ -75,7 +75,7 @@ export const SourceClusterProjectStep: React.FunctionComponent = () => {
           formGroupProps={credentialsFormGroupProps}
         />
         <ValidatedTextInput
-          field={form.fields.namespace}
+          field={form.fields.sourceNamespace}
           isRequired
           fieldId="project-name"
           greenWhenValid

--- a/src/components/ImportWizard/SourceProjectDetailsStep.tsx
+++ b/src/components/ImportWizard/SourceProjectDetailsStep.tsx
@@ -28,7 +28,7 @@ export const SourceProjectDetailsStep: React.FunctionComponent = () => {
     >
       <TextContent className={spacing.mbXl}>
         <Text component="h2">Project details</Text>
-        <Text component="h3">{forms.sourceClusterProject.values.namespace}</Text>
+        <Text component="h3">{forms.sourceClusterProject.values.sourceNamespace}</Text>
       </TextContent>
       <TableComposable
         aria-label="Project details table"
@@ -47,14 +47,6 @@ export const SourceProjectDetailsStep: React.FunctionComponent = () => {
           <Tr>
             <Th className={spacing.pr_2xl}>Services</Th>
             <Td id="details-services">{sourceServicesQuery.data?.data.items.length}</Td>
-          </Tr>
-          <Tr>
-            <Th className={spacing.pr_2xl}>Images</Th>
-            <Td id="details-images">TODO</Td>
-          </Tr>
-          <Tr>
-            <Th className={spacing.pr_2xl}>Total image size</Th>
-            <Td id="details-imagesize">TODO</Td>
           </Tr>
         </Tbody>
       </TableComposable>

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { ObjectReference } from '@openshift-console/dynamic-plugin-sdk';
+import { K8sResourceCommon, ObjectReference } from '@openshift-console/dynamic-plugin-sdk';
 import { PersistentVolumeClaim } from 'src/api/types/PersistentVolume';
 
 export const isSameResource = (
@@ -17,3 +17,11 @@ export const isSameResource = (
 
 export const getCapacity = (pvc: PersistentVolumeClaim) =>
   pvc.status?.capacity?.storage || pvc.spec.resources.requests.storage;
+
+export const getObjectRef = (resource: K8sResourceCommon): ObjectReference => ({
+  apiVersion: resource.apiVersion,
+  kind: resource.kind,
+  name: resource.metadata.name,
+  namespace: resource.metadata.namespace,
+  uid: resource.metadata.uid,
+});

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -5,8 +5,6 @@ import { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-serv
 import * as path from 'path';
 import { ConsoleRemotePlugin } from '@openshift-console/dynamic-plugin-sdk-webpack';
 import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 
 interface Configuration extends WebpackConfiguration {
   devServer?: WebpackDevServerConfiguration;
@@ -76,9 +74,6 @@ const config: Configuration = {
     new EnvironmentPlugin({
       NODE_ENV: 'development',
       DATA_SOURCE: 'api',
-    }),
-    new MonacoWebpackPlugin({
-      languages: ['yaml'],
     }),
   ],
   devtool: 'source-map',

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -5,6 +5,8 @@ import { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-serv
 import * as path from 'path';
 import { ConsoleRemotePlugin } from '@openshift-console/dynamic-plugin-sdk-webpack';
 import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 
 interface Configuration extends WebpackConfiguration {
   devServer?: WebpackDevServerConfiguration;
@@ -74,6 +76,9 @@ const config: Configuration = {
     new EnvironmentPlugin({
       NODE_ENV: 'development',
       DATA_SOURCE: 'api',
+    }),
+    new MonacoWebpackPlugin({
+      languages: ['yaml'],
     }),
   ],
   devtool: 'source-map',


### PR DESCRIPTION
I believe this PR brings the UI to feature-complete for our alpha milestone 🎉 

* TypeScript types for Tekton resources have been copied [from the Tekton UI codebase](https://github.com/openshift/console/tree/3348a3bd2fa852a9592ddeb79fd7735b06e875bd/frontend/packages/pipelines-plugin/src/types) (maybe some day we can find a way to expose those for proper reuse). See [`src/api/types/pipeline-plugin/README.md`](https://github.com/konveyor/crane-ui-plugin/compare/main...mturley%3Agenerate-pipeline?expand=1#diff-6d1d9d7924b229dc0447c49764d82f83af1e38bdd693570be72b0f22a3474f8f).
* A (temporary?) field for "Destination cluster OAuth token" has been added to the first wizard step.
* Image and Image Size have been removed from the Project Details step per discussion on Slack.
* On the Pipeline Settings step, the pipeline name is validated against existing pipelines to make sure it is unique.
* Upon reaching the Review step of the wizard, a secret is created for the destination cluster using the token collected above and the URL `https://kubernetes.default.svc`. If there is an existing secret using that URL that is not associated with another pipeline (does not have `ownerReferences`), it will be patched and reused instead of creating a new secret (similar to the behavior of the source cluster secret implemented in #23).
* After the destination secret is created, YAML is generated and prefilled in the editors for a Pipeline and PipelineRun based on the user's input in prior wizard steps (the secret for the source cluster already exists because it was used to configure the proxy on the first wizard step, see #23)
  * The Pipeline and PipelineRun objects are generated by the `formsToTektonResources` function, which currently is just a 1-to-1 paste of the structure from the ["Stateless Application Migration" user story](https://github.com/konveyor/enhancements/pull/59/files#diff-de16b44d1c009b96ec73f4a946784d97949fdacbe56041d7e5023e6cc8f18df3R602) described in https://github.com/konveyor/enhancements/pull/59, with the user's form values filled in. For future use cases where these resources will vary in structure we'll need to have some more dynamic logic here, but this works for now. Lines where user input is filled in are called out by `// <--` comments:
    * Pipeline
      * `metadata.name`
      * `metadata.namespace`
    * PipelineRun
      * `metadata.generateName`
      * `metadata.namespace`
      * `spec.status`
      * `spec.params[].value` (for `source-cluster-secret`, `destination-cluster-secret` and `source-namespace`)
* The user can edit the YAML, and any invalid YAML syntax will be called out with errors along the bottom of the page. Note that syntax highlighting is not currently working (I was running into errors when setting up monaco-editor-webpack-plugin due to conflicting versions with the latest PatternFly code editor and the code editor built into the OpenShift console, which is not yet exposed by their plugin SDK). The editor experience will be made more consistent with the rest of OpenShift in a future PR.
* When the YAML is valid, the user can submit the wizard.
  * The Pipeline and PipelineRun are created
  * `ownerReferences` to the Pipeline are patched onto both secrets
  * The browser is navigated to the page for the new PipelineRun in the Tekton UI.

Notes for future improvement:
* See above issues with the YAML editor (there's also some wonky layout there in certain conditions, will follow up with an issue)
* If the user navigates back from the Review step to earlier in the wizard, they will lose any custom edits they've made to the YAML (it gets generated from the form values again each time you reach the Review step). I want to add a warning before letting the user leave that step if they have made edits to the YAML.
* As mentioned above, only stateless applications are supported so far. If the user selects any PVCs, they will not be included in the resulting Pipeline/PipelineRun yet.

# Enjoy my annoying temporary help text

![Screen Shot 2022-02-15 at 10 13 11 PM](https://user-images.githubusercontent.com/811963/154189252-f7f97110-8e69-4d38-912c-9655025f8b7a.png)

# Check it out, it's working

![viYQ7Gv3xe](https://user-images.githubusercontent.com/811963/154189089-3a911f0b-d772-4f4c-bc2d-b602ce85ff7f.gif)

