### PR TITLE
Remove references to crane-proxy configmap, temporarily allow navigation without validating credentials

### DIFF
--- a/src/api/queries/secrets.ts
+++ b/src/api/queries/secrets.ts
@@ -3,19 +3,15 @@ import {
   useK8sModel,
   k8sList,
   k8sCreate,
-  k8sGet,
   k8sPatch,
   k8sDelete,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { K8sModel } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
 import { useMutation } from 'react-query';
 import { useNamespaceContext } from 'src/context/NamespaceContext';
-import { isSameResource } from 'src/utils/helpers';
-import { ProxyConfigMap, ProxyConfigMapCluster } from '../types/ConfigMap';
 import { OAuthSecret, Secret } from '../types/Secret';
 
 export const secretGVK: K8sGroupVersionKind = { group: '', version: 'v1', kind: 'Secret' };
-export const configMapGVK: K8sGroupVersionKind = { group: '', version: 'v1', kind: 'ConfigMap' };
 
 interface UseConfigureSecretMutationArgs {
   existingSecretFromState: OAuthSecret | null;
@@ -31,7 +27,6 @@ export const useConfigureProxyMutation = ({
   onSuccess,
 }: UseConfigureSecretMutationArgs) => {
   const [secretModel] = useK8sModel(secretGVK);
-  const [configMapModel] = useK8sModel(configMapGVK);
   const namespace = useNamespaceContext();
   return useMutation<OAuthSecret, Error, ConfigureProxyMutationParams>(
     async ({ apiUrl, token }) => {
@@ -42,44 +37,19 @@ export const useConfigureProxyMutation = ({
         existingSecret = await findExistingSecret(secretModel, namespace, apiUrl, 'source');
       }
 
-      let secretToUse: OAuthSecret | null = null;
-      let deletedSecret: OAuthSecret | null = null;
-
-      // If we have an existing secret that doesn't match our credentials, delete it so we can replace it.
+      // If we have an existing secret that matches our credentials, we can just use it as-is.
       if (existingSecret) {
-        if (!secretMatchesCredentials(existingSecret, apiUrl, token)) {
-          await k8sDelete({ model: secretModel, resource: existingSecret });
-          deletedSecret = existingSecret;
-        } else {
-          // If it already matches, we can just use it as-is.
-          secretToUse = existingSecret;
+        if (secretMatchesCredentials(existingSecret, apiUrl, token)) {
+          return existingSecret;
         }
+        // If it doesn't match our credentials we delete it so we can replace it.
+        await k8sDelete({ model: secretModel, resource: existingSecret });
       }
 
-      if (!secretToUse) {
-        secretToUse = await k8sCreate<OAuthSecret>({
-          model: secretModel,
-          data: getNewSecret('source', namespace, apiUrl, token),
-        });
-      }
-
-      // Patch the proxy ConfigMap to add the new secret and remove the deleted secret if applicable
-      const proxyConfigMap = await k8sGet<ProxyConfigMap>({
-        model: configMapModel,
-        ns: 'openshift-migration',
-        name: 'crane-proxy',
+      return await k8sCreate<OAuthSecret>({
+        model: secretModel,
+        data: getNewSecret('source', namespace, apiUrl, token),
       });
-      let newClustersJSON = addSecretToClustersJSON(proxyConfigMap.data.clusters, secretToUse);
-      if (deletedSecret) {
-        newClustersJSON = removeSecretFromClustersJSON(newClustersJSON, deletedSecret);
-      }
-      await k8sPatch<ProxyConfigMap>({
-        model: configMapModel,
-        resource: proxyConfigMap,
-        data: [{ op: 'replace', path: '/data/clusters', value: newClustersJSON }],
-      });
-
-      return secretToUse;
     },
     { onSuccess },
   );
@@ -160,28 +130,6 @@ const getNewSecret = (
   },
   type: 'Opaque',
 });
-
-const parseClustersJSON = (clustersJSON: string): ProxyConfigMapCluster[] => {
-  try {
-    return JSON.parse(clustersJSON);
-  } catch {
-    return [];
-  }
-};
-
-const removeSecretFromClustersJSON = (clustersJSON: string, secret: OAuthSecret): string => {
-  let clusters = parseClustersJSON(clustersJSON);
-  clusters = clusters.filter((secretRef) => !isSameResource(secretRef, secret.metadata));
-  return JSON.stringify(clusters);
-};
-
-const addSecretToClustersJSON = (clustersJSON: string, secret: OAuthSecret): string => {
-  const clusters = parseClustersJSON(clustersJSON);
-  if (!clusters.find((secretRef) => isSameResource(secretRef, secret.metadata))) {
-    clusters.push({ name: secret.metadata.name, namespace: secret.metadata.namespace });
-  }
-  return JSON.stringify(clusters);
-};
 
 export const secretMatchesCredentials = (secret: OAuthSecret, apiUrl: string, token: string) =>
   secret.data.url === btoa(apiUrl) && secret.data.token === btoa(token);

--- a/src/api/types/ConfigMap.ts
+++ b/src/api/types/ConfigMap.ts
@@ -7,14 +7,3 @@ export interface ConfigMap extends K8sResourceCommon {
   kind: 'ConfigMap';
   data: Record<string, string>;
 }
-
-export interface ProxyConfigMap extends ConfigMap {
-  data: {
-    clusters: string; // JSON like { namespace: string; name: string; }[]
-  };
-}
-
-export interface ProxyConfigMapCluster {
-  namespace: string;
-  name: string;
-}

--- a/src/components/ImportWizard/ImportWizard.tsx
+++ b/src/components/ImportWizard/ImportWizard.tsx
@@ -73,7 +73,7 @@ export const ImportWizard: React.FunctionComponent = () => {
     ? 'Confirm or cancel row edits before proceeding'
     : null;
   const canMoveToStep = (stepId: StepId) =>
-    !allNavDisabled && stepId >= 0 && stepIdReached >= stepId;
+    (!allNavDisabled && stepId >= 0 && stepIdReached >= stepId) || true; // TODO remove the || true case, this temporarily circumvents the admin-only credentials validation (see https://github.com/konveyor/crane-ui-plugin/issues/30)
 
   /*
   const allMutationResults = []; // TODO do we need this?


### PR DESCRIPTION
Resolves #31 

Also prevents errors on the first wizard step from blocking wizard navigation, as a temporary workaround for #30.