### PR TITLE
bug: kubeconfig generators must be run synchronously

### DIFF
--- a/src/api/pipelineHelpers.ts
+++ b/src/api/pipelineHelpers.ts
@@ -76,6 +76,7 @@ export const formsToTektonResources = (
         },
         {
           name: 'generate-destination-kubeconfig',
+          runAfter: ['generate-source-kubeconfig'],
           params: [
             {
               name: 'cluster-secret',
@@ -99,7 +100,7 @@ export const formsToTektonResources = (
         },
         {
           name: 'export',
-          runAfter: ['generate-source-kubeconfig', 'generate-destination-kubeconfig'],
+          runAfter: ['generate-destination-kubeconfig'],
           params: [
             {
               name: 'context',


### PR DESCRIPTION
Allowing the source + destination cluster kubeconfigs to be generated
at the same time creates a race condition.