### PR TITLE
Enable TypeScript strict mode, satisfy strict null check errors

### DIFF
--- a/src/api/pipelineHelpers.ts
+++ b/src/api/pipelineHelpers.ts
@@ -242,11 +242,11 @@ export const formsToTektonResources = (
       params: [
         {
           name: 'source-cluster-secret',
-          value: sourceApiSecret.metadata.name, // <--
+          value: sourceApiSecret?.metadata.name || '', // <--
         },
         {
           name: 'destination-cluster-secret',
-          value: destinationApiSecret.metadata.name, // <--
+          value: destinationApiSecret?.metadata.name || '', // <--
         },
         {
           name: 'source-namespace',

--- a/src/api/proxyHelpers.ts
+++ b/src/api/proxyHelpers.ts
@@ -40,7 +40,7 @@ export interface IProxyK8sStatus extends K8sResourceCommon {
   };
 }
 
-export const getProxyApiUrl = (clusterSecret?: OAuthSecret) => {
+export const getProxyApiUrl = (clusterSecret: OAuthSecret | null) => {
   const proxyRootUrl = `/api/proxy/plugin/crane-ui-plugin/remote-cluster`;
   return `${proxyRootUrl}/${clusterSecret?.metadata.namespace}/${clusterSecret?.metadata.name}`;
 };
@@ -50,7 +50,7 @@ export interface OAuthUser {
   expiry_time?: number;
 }
 
-export const useProxyK8sClient = (clusterSecret?: OAuthSecret) => {
+export const useProxyK8sClient = (clusterSecret: OAuthSecret | null) => {
   if (!clusterSecret) return null;
   const clusterApiUrl = getProxyApiUrl(clusterSecret);
   const client = ClientFactory.cluster(
@@ -85,12 +85,12 @@ export const useProxyK8sClient = (clusterSecret?: OAuthSecret) => {
 export const areSourceCredentialsValid = (
   apiUrlField: IFormField<string>,
   tokenField: IFormField<string>,
-  sourceApiSecretField: IFormField<OAuthSecret>,
+  sourceApiSecretField: IFormField<OAuthSecret | null>,
   sourceApiRootQuery: ReturnType<typeof useSourceApiRootQuery>,
 ) =>
   !apiUrlField.isDirty &&
   !tokenField.isDirty &&
-  sourceApiSecretField.value &&
+  !!sourceApiSecretField.value &&
   secretMatchesCredentials(sourceApiSecretField.value, apiUrlField.value, tokenField.value) &&
   sourceApiRootQuery.isSuccess &&
   sourceApiRootQuery.data?.kind === 'APIVersions';

--- a/src/api/queries/secrets.ts
+++ b/src/api/queries/secrets.ts
@@ -34,7 +34,8 @@ export const useConfigureProxyMutation = ({
       let existingSecret = existingSecretFromState;
       if (!existingSecret) {
         // See if we have an existing secret for this cluster URL that isn't associated with a pipeline.
-        existingSecret = await findExistingSecret(secretModel, namespace, apiUrl, 'source');
+        existingSecret =
+          (await findExistingSecret(secretModel, namespace, apiUrl, 'source')) || null;
       }
 
       // If we have an existing secret that matches our credentials, we can just use it as-is.
@@ -72,7 +73,8 @@ export const useConfigureDestinationSecretMutation = ({
       let existingSecret = existingSecretFromState;
       if (!existingSecret) {
         // See if we have an existing secret for this cluster URL that isn't associated with a pipeline.
-        existingSecret = await findExistingSecret(secretModel, namespace, apiUrl, 'destination');
+        existingSecret =
+          (await findExistingSecret(secretModel, namespace, apiUrl, 'destination')) || null;
       }
       const updatedSecret = existingSecret
         ? await k8sPatch({
@@ -102,7 +104,7 @@ const findExistingSecret = async (
   });
   return nsSecrets.find(
     (secret) =>
-      secret.metadata.annotations?.['konveyor.io/crane-ui-plugin'] ===
+      secret.metadata?.annotations?.['konveyor.io/crane-ui-plugin'] ===
         `${sourceOrDestination}-cluster-oauth` &&
       (secret.metadata.ownerReferences || []).length === 0 &&
       secret.data.url === btoa(apiUrl),

--- a/src/api/queries/sourceResources.ts
+++ b/src/api/queries/sourceResources.ts
@@ -8,13 +8,13 @@ import { Pod } from '../types/Pod';
 import { PersistentVolumeClaim } from '../types/PersistentVolume';
 import { Service } from '../types/Service';
 
-export const useSourceApiRootQuery = (sourceApiSecret?: OAuthSecret, isEnabled = true) => {
+export const useSourceApiRootQuery = (sourceApiSecret: OAuthSecret | null, isEnabled = true) => {
   const apiRootUrl = `${getProxyApiUrl(sourceApiSecret)}/api`;
   return useQuery<ApiRootQueryResponse>(['api-root', sourceApiSecret?.metadata.name], {
     queryFn: async () =>
       (
         await fetch(apiRootUrl, {
-          headers: { Authorization: `Bearer ${atob(sourceApiSecret.data.token)}` },
+          headers: { Authorization: `Bearer ${atob(sourceApiSecret?.data.token || '')}` },
         })
       ).json(),
     enabled: !!sourceApiSecret && isEnabled,
@@ -28,14 +28,14 @@ export const useValidateSourceNamespaceQuery = (
 ) => {
   const client = useProxyK8sClient(sourceApiSecret);
   return useQuery(['namespace', namespace], {
-    queryFn: () => client.get(namespaceResource, namespace),
+    queryFn: () => client?.get(namespaceResource, namespace),
     enabled: !!sourceApiSecret && !!namespace && isEnabled,
     retry: false,
   });
 };
 
 interface UseSourceNamespacedQueryArgs {
-  sourceApiSecret?: OAuthSecret;
+  sourceApiSecret: OAuthSecret | null;
   sourceNamespace: string;
 }
 
@@ -46,7 +46,7 @@ const useSourceNamespacedListQuery = <T extends K8sResourceCommon>(
   const client = useProxyK8sClient(sourceApiSecret);
   const resource = new CoreNamespacedResource(kindPlural, sourceNamespace);
   return useQuery([kindPlural, sourceApiSecret?.metadata.name, sourceNamespace], {
-    queryFn: () => client.list<T>(resource),
+    queryFn: () => client?.list<T>(resource),
     enabled: !!sourceApiSecret,
     refetchInterval: 15_000,
   });

--- a/src/common/components/SimpleSelectMenu.tsx
+++ b/src/common/components/SimpleSelectMenu.tsx
@@ -25,11 +25,13 @@ export const SimpleSelectMenu = <T extends string | number>({
 
   React.useEffect(() => {
     const handleMenuKeys = (event: KeyboardEvent) => {
-      if (isOpen && menuRef.current?.contains(event.target as Node)) {
-        if (event.key === 'Escape' || event.key === 'Tab') {
-          setIsOpen(!isOpen);
-          toggleRef.current?.focus();
-        }
+      if (
+        isOpen &&
+        menuRef.current?.contains(event.target as Node) &&
+        (event.key === 'Escape' || event.key === 'Tab')
+      ) {
+        setIsOpen(!isOpen);
+        toggleRef.current?.focus();
       }
     };
     const handleClickOutside = (event: MouseEvent) => {
@@ -57,13 +59,18 @@ export const SimpleSelectMenu = <T extends string | number>({
   };
 
   const toggle = (
-    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen} {...toggleProps}>
+    <MenuToggle
+      ref={toggleRef as React.Ref<HTMLButtonElement>}
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      {...toggleProps}
+    >
       {selectedLabel}
     </MenuToggle>
   );
   const menu = (
     <Menu
-      ref={menuRef}
+      ref={menuRef as React.Ref<HTMLDivElement>}
       id="select-menu"
       onSelect={(_ev, itemId) => {
         setSelected(itemId as T);

--- a/src/common/schema.ts
+++ b/src/common/schema.ts
@@ -31,7 +31,7 @@ export const getSourceNamespaceSchema = (
       });
     }
     return true;
-  });
+  }) as yup.StringSchema<string>;
 
 export const capacitySchema = yup.string().matches(/^(\d+)[KMGTP]i?$/, {
   message: ({ label }) =>
@@ -46,10 +46,11 @@ export const yamlSchema = yup.string().test({
     try {
       yaml.load(value || '');
     } catch (e) {
-      if (e.reason && e.mark) {
+      const error = e as { reason?: string; mark?: { line?: number; column?: number } };
+      if (error.reason && error.mark) {
         return context.createError({
-          message: `${context.schema.describe().label}: ${e.reason} (${e.mark.line}:${
-            e.mark.column
+          message: `${context.schema.describe().label}: ${error.reason} (${error.mark.line}:${
+            error.mark.column
           })`,
         });
       }
@@ -69,5 +70,5 @@ export const getPipelineNameSchema = (pipelinesWatch: ReturnType<typeof useWatch
       'A pipeline with this name already exists',
       (value) =>
         !pipelinesWatch.loaded ||
-        !pipelinesWatch.data?.find((pipeline) => pipeline.metadata.name === value),
+        !pipelinesWatch.data?.find((pipeline) => pipeline.metadata?.name === value),
     );

--- a/src/components/ImportWizard/ImportWizard.tsx
+++ b/src/components/ImportWizard/ImportWizard.tsx
@@ -61,9 +61,9 @@ export const ImportWizard: React.FunctionComponent = () => {
     return newStepId;
   };
 
-  const firstInvalidFormStepId = Object.values(StepId).find(
-    (id: StepId) => formsByStepId[id] && !hiddenStepIds.includes(id) && !formsByStepId[id].isValid,
-  ) as StepId | undefined;
+  const firstInvalidFormStepId = (Object.values(StepId) as StepId[]).find(
+    (id: StepId) => formsByStepId[id] && !hiddenStepIds.includes(id) && !formsByStepId[id]?.isValid,
+  );
   const stepIdReached =
     firstInvalidFormStepId !== undefined ? firstInvalidFormStepId : StepId.Review + 1;
 
@@ -105,7 +105,7 @@ export const ImportWizard: React.FunctionComponent = () => {
   const createTektonResourcesMutation = useCreateTektonResourcesMutation((newResources) => {
     // On success, navigate to the Tekton UI!
     history.push(
-      `/k8s/ns/${namespace}/tekton.dev~v1beta1~PipelineRun/${newResources.pipelineRun.metadata.name}`,
+      `/k8s/ns/${namespace}/tekton.dev~v1beta1~PipelineRun/${newResources.pipelineRun.metadata?.name}`,
     );
   });
 

--- a/src/components/ImportWizard/ImportWizardFormContext.tsx
+++ b/src/components/ImportWizard/ImportWizardFormContext.tsx
@@ -72,15 +72,17 @@ export const useImportWizardFormState = () => {
     const defaultEditValuesByPVC: PVCEditValuesByPVCName = {};
     const defaultStorageClass = storageClassesWatch.data?.find(isDefaultStorageClass);
     selectedPVCs.forEach((pvc) => {
-      defaultIsEditModeByPVC[pvc.metadata.name] = false;
-      const defaultEditValues: PVCEditRowFormValues = {
-        targetPvcName: pvc.metadata.name,
-        storageClass: defaultStorageClass?.metadata.name || '',
-        capacity: getCapacity(pvc),
-        verifyCopy: false,
-      };
-      defaultEditValuesByPVC[pvc.metadata.name] =
-        editValuesByPVCField.value[pvc.metadata.name] || defaultEditValues;
+      if (pvc.metadata?.name) {
+        defaultIsEditModeByPVC[pvc.metadata.name] = false;
+        const defaultEditValues: PVCEditRowFormValues = {
+          targetPvcName: pvc.metadata.name,
+          storageClass: defaultStorageClass?.metadata.name || '',
+          capacity: getCapacity(pvc),
+          verifyCopy: false,
+        };
+        defaultEditValuesByPVC[pvc.metadata.name] =
+          editValuesByPVCField.value[pvc.metadata.name] || defaultEditValues;
+      }
     });
     isEditModeByPVCField.reinitialize(defaultIsEditModeByPVC);
     editValuesByPVCField.reinitialize(defaultEditValuesByPVC);

--- a/src/components/ImportWizard/PVCEditStep.tsx
+++ b/src/components/ImportWizard/PVCEditStep.tsx
@@ -28,7 +28,9 @@ export const PVCEditStep: React.FunctionComponent = () => {
 
   const rowFilters: RowFilter<PersistentVolumeClaim>[] = []; // TODO do we need to add one here for storage classes, by the available ones in the source?
   const [data, filteredData, onFilterChange] = useListPageFilter(selectedPVCs, rowFilters);
-  const { sortBy, onSort, sortedItems } = useSortState(filteredData, (pvc) => [pvc.metadata.name]);
+  const { sortBy, onSort, sortedItems } = useSortState(filteredData, (pvc) => [
+    pvc.metadata?.name || '',
+  ]);
 
   return (
     <>
@@ -59,26 +61,29 @@ export const PVCEditStep: React.FunctionComponent = () => {
             </Tr>
           </Thead>
           <Tbody>
-            {sortedItems.map((pvc) => (
-              <PVCEditStepTableRow
-                key={pvc.metadata.name}
-                pvc={pvc}
-                existingValues={form.values.editValuesByPVC[pvc.metadata.name]}
-                setEditedValues={(newValues) => {
-                  form.fields.editValuesByPVC.setValue((oldValues) => ({
-                    ...oldValues,
-                    [pvc.metadata.name]: newValues,
-                  }));
-                }}
-                isEditMode={form.values.isEditModeByPVC[pvc.metadata.name]}
-                setIsEditMode={(isEditMode) => {
-                  form.fields.isEditModeByPVC.setValue((oldValues) => ({
-                    ...oldValues,
-                    [pvc.metadata.name]: isEditMode,
-                  }));
-                }}
-              />
-            ))}
+            {sortedItems.map((pvc) => {
+              const pvcName = pvc.metadata?.name || '';
+              return (
+                <PVCEditStepTableRow
+                  key={pvcName}
+                  pvc={pvc}
+                  existingValues={form.values.editValuesByPVC[pvcName]}
+                  setEditedValues={(newValues) => {
+                    form.fields.editValuesByPVC.setValue((oldValues) => ({
+                      ...oldValues,
+                      [pvcName]: newValues,
+                    }));
+                  }}
+                  isEditMode={form.values.isEditModeByPVC[pvcName]}
+                  setIsEditMode={(isEditMode) => {
+                    form.fields.isEditModeByPVC.setValue((oldValues) => ({
+                      ...oldValues,
+                      [pvcName]: isEditMode,
+                    }));
+                  }}
+                />
+              );
+            })}
           </Tbody>
         </TableComposable>
       </Form>

--- a/src/components/ImportWizard/PVCEditStepTableRow.tsx
+++ b/src/components/ImportWizard/PVCEditStepTableRow.tsx
@@ -28,17 +28,17 @@ export const PVCEditStepTableRow: React.FunctionComponent<PVCEditStepTableRowPro
   setIsEditMode,
 }) => {
   const storageClassWatch = useWatchStorageClasses();
-
   const rowForm = usePVCEditRowFormState(existingValues);
+  const pvcName = pvc.metadata?.name || '';
 
   return (
-    <Tr key={pvc.metadata.name}>
-      <Td dataLabel={columnNames.sourcePvcName}>{pvc.metadata.name}</Td>
+    <Tr key={pvcName}>
+      <Td dataLabel={columnNames.sourcePvcName}>{pvcName}</Td>
       <Td dataLabel={columnNames.targetPvcName}>
         {isEditMode ? (
           <ValidatedTextInput
             field={rowForm.fields.targetPvcName}
-            fieldId={`target-pvc-name-${pvc.metadata.name}`}
+            fieldId={`target-pvc-name-${pvcName}`}
             label={null}
           />
         ) : (
@@ -51,7 +51,7 @@ export const PVCEditStepTableRow: React.FunctionComponent<PVCEditStepTableRowPro
             selected={rowForm.values.storageClass}
             setSelected={rowForm.fields.storageClass.setValue}
             toggleProps={{ style: { width: '100%' } }}
-            id={`storage-class-select-${pvc.metadata.name}`}
+            id={`storage-class-select-${pvcName}`}
           >
             <MenuContent>
               <MenuList>
@@ -72,7 +72,7 @@ export const PVCEditStepTableRow: React.FunctionComponent<PVCEditStepTableRowPro
         {isEditMode ? (
           <ValidatedTextInput
             field={rowForm.fields.capacity}
-            fieldId={`capacity-${pvc.metadata.name}`}
+            fieldId={`capacity-${pvcName}`}
             label={null}
           />
         ) : (
@@ -81,11 +81,11 @@ export const PVCEditStepTableRow: React.FunctionComponent<PVCEditStepTableRowPro
       </Td>
       <Td dataLabel={columnNames.verifyCopy} textCenter>
         <Checkbox
-          aria-label={`Verify copy for PVC ${pvc.metadata.name}`}
+          aria-label={`Verify copy for PVC ${pvcName}`}
           isDisabled={!isEditMode}
           isChecked={rowForm.values.verifyCopy}
           onChange={rowForm.fields.verifyCopy.setValue}
-          id={`verify-copy-${pvc.metadata.name}`}
+          id={`verify-copy-${pvcName}`}
         />
       </Td>
       <Td modifier="nowrap">

--- a/src/components/ImportWizard/PVCSelectStep.tsx
+++ b/src/components/ImportWizard/PVCSelectStep.tsx
@@ -28,7 +28,9 @@ export const PVCSelectStep: React.FunctionComponent = () => {
   const rowFilters: RowFilter<PersistentVolumeClaim>[] = []; // TODO do we need to add one here for storage classes, by the available ones in the source?
   const [data, filteredData, onFilterChange] = useListPageFilter(pvcs, rowFilters);
 
-  const { sortBy, onSort, sortedItems } = useSortState(filteredData, (pvc) => [pvc.metadata.name]);
+  const { sortBy, onSort, sortedItems } = useSortState(filteredData, (pvc) => [
+    pvc.metadata?.name || '',
+  ]);
 
   const { isItemSelected, toggleItemSelected, areAllSelected, selectAll } = useSelectionState({
     items: pvcs,
@@ -92,38 +94,41 @@ export const PVCSelectStep: React.FunctionComponent = () => {
                 </Td>
               </Tr>
             ) : (
-              sortedItems.map((pvc, rowIndex) => (
-                <Tr key={pvc.metadata.name}>
-                  <Td
-                    select={{
-                      rowIndex,
-                      onSelect: (_event, isSelecting) => toggleItemSelected(pvc, isSelecting),
-                      isSelected: isItemSelected(pvc),
-                    }}
-                  />
-                  <Td dataLabel={columnNames.pvcName}>{pvc.metadata.name}</Td>
-                  <Td dataLabel={columnNames.storageClass}>{pvc.spec.storageClassName}</Td>
-                  <Td dataLabel={columnNames.capacity}>{getCapacity(pvc)}</Td>
-                  <Td>
-                    <Popover
-                      className="json-popover"
-                      position="bottom"
-                      bodyContent={
-                        <div onClick={(event) => event.stopPropagation()}>
-                          <ReactJson src={pvc} enableClipboard={false} />
-                        </div>
-                      }
-                      aria-label={`View JSON for PVC ${pvc.metadata.name}`}
-                      closeBtnAriaLabel="Close JSON view"
-                      maxWidth="200rem"
-                    >
-                      <Button variant="link" className={text.textNowrap}>
-                        View JSON
-                      </Button>
-                    </Popover>
-                  </Td>
-                </Tr>
-              ))
+              sortedItems.map((pvc, rowIndex) => {
+                const pvcName = pvc.metadata?.name;
+                return (
+                  <Tr key={pvcName}>
+                    <Td
+                      select={{
+                        rowIndex,
+                        onSelect: (_event, isSelecting) => toggleItemSelected(pvc, isSelecting),
+                        isSelected: isItemSelected(pvc),
+                      }}
+                    />
+                    <Td dataLabel={columnNames.pvcName}>{pvcName}</Td>
+                    <Td dataLabel={columnNames.storageClass}>{pvc.spec.storageClassName}</Td>
+                    <Td dataLabel={columnNames.capacity}>{getCapacity(pvc)}</Td>
+                    <Td>
+                      <Popover
+                        className="json-popover"
+                        position="bottom"
+                        bodyContent={
+                          <div onClick={(event) => event.stopPropagation()}>
+                            <ReactJson src={pvc} enableClipboard={false} />
+                          </div>
+                        }
+                        aria-label={`View JSON for PVC ${pvcName}`}
+                        closeBtnAriaLabel="Close JSON view"
+                        maxWidth="200rem"
+                      >
+                        <Button variant="link" className={text.textNowrap}>
+                          View JSON
+                        </Button>
+                      </Popover>
+                    </Td>
+                  </Tr>
+                );
+              })
             )}
           </Tbody>
         </TableComposable>

--- a/src/utils/actions.ts
+++ b/src/utils/actions.ts
@@ -7,7 +7,7 @@ import { importIconElement } from './icons';
 type TopologyActionProvider = (data: {
   element: GraphElement;
   connectorSource?: Node;
-}) => [Action[], boolean, Error];
+}) => [Action[], boolean, Error | undefined];
 
 // Based on https://github.com/openshift/console/blob/d7b965d/frontend/packages/dev-console/src/actions/providers.ts#L66
 export const useTopologyGraphActionProvider: TopologyActionProvider = ({ element }) =>

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -7,13 +7,15 @@ export const isSameResource = (
 ): boolean =>
   !!refA &&
   !!refB &&
-  ((refA.uid && refB.uid && refA.uid === refB.uid) ||
+  !!(
+    (refA.uid && refB.uid && refA.uid === refB.uid) ||
     (refA.name &&
       refB.name &&
       refA.namespace &&
       refB.namespace &&
       refA.name === refB.name &&
-      refA.namespace === refB.namespace));
+      refA.namespace === refB.namespace)
+  );
 
 export const getCapacity = (pvc: PersistentVolumeClaim) =>
   pvc.status?.capacity?.storage || pvc.spec.resources.requests.storage;
@@ -21,7 +23,7 @@ export const getCapacity = (pvc: PersistentVolumeClaim) =>
 export const getObjectRef = (resource: K8sResourceCommon): ObjectReference => ({
   apiVersion: resource.apiVersion,
   kind: resource.kind,
-  name: resource.metadata.name,
-  namespace: resource.metadata.namespace,
-  uid: resource.metadata.uid,
+  name: resource.metadata?.name,
+  namespace: resource.metadata?.namespace,
+  uid: resource.metadata?.uid,
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "es2020",
     "jsx": "react",
     "allowJs": true,
-    "strict": false,
+    "strict": true,
     "noUnusedLocals": true,
     "skipLibCheck": true
   },


### PR DESCRIPTION
I noticed some weirdness around null/undefined values when developing that would have been caught sooner had I enabled TypeScript's strict mode. This PR enables that mode and addresses all resulting errors by adding null checks where necessary.