### PR TITLE
Add support for stage/cutover of stateful apps

### DIFF
--- a/src/api/pipelineHelpers.ts
+++ b/src/api/pipelineHelpers.ts
@@ -1,10 +1,13 @@
 import { ImportWizardFormState } from 'src/components/ImportWizard/ImportWizardFormContext';
+import { getAllPipelineTasks } from './pipelineTaskHelpers';
 import { PipelineKind, PipelineRunKind } from './types/pipelines-plugin';
 import { OAuthSecret } from './types/Secret';
 
 export interface WizardTektonResources {
-  pipeline: PipelineKind;
-  pipelineRun: PipelineRunKind;
+  stagePipeline: PipelineKind | null;
+  stagePipelineRun: PipelineRunKind | null;
+  cutoverPipeline: PipelineKind;
+  cutoverPipelineRun: PipelineRunKind;
 }
 
 export const formsToTektonResources = (
@@ -13,279 +16,125 @@ export const formsToTektonResources = (
   namespace: string,
 ): WizardTektonResources => {
   const { sourceNamespace, sourceApiSecret } = forms.sourceClusterProject.values;
-  // const { selectedPVCs } = forms.pvcSelect.values;
-  // const { editValuesByPVC } = forms.pvcEdit.values;
   const { pipelineName, startImmediately } = forms.pipelineSettings.values;
+  const { selectedPVCs } = forms.pvcSelect.values;
+  const isStatefulMigration = selectedPVCs.length > 0;
 
-  // TODO these resources are only for stateless applications, dropped in 1-to-1 from that section of User Stories in https://github.com/konveyor/enhancements/pull/59.
-  // TODO we'll need to make this more dynamic to support all user stories in there, either via logic in this helper or by breaking the stories into individual helpers.
-
-  const pipeline: PipelineKind = {
+  const pipelineCommon: PipelineKind = {
     apiVersion: 'tekton.dev/v1beta1',
     kind: 'Pipeline',
-    metadata: {
-      name: pipelineName, // <--
-      namespace, // <--
-    },
     spec: {
       params: [
-        {
-          name: 'source-cluster-secret',
-          type: 'string',
-        },
-        {
-          name: 'source-namespace',
-          type: 'string',
-        },
-        {
-          name: 'destination-cluster-secret',
-          type: 'string',
-        },
+        { name: 'source-cluster-secret', type: 'string' },
+        { name: 'source-namespace', type: 'string' },
+        { name: 'destination-cluster-secret', type: 'string' },
       ],
-      workspaces: [
-        {
-          name: 'shared-data',
-        },
-        {
-          name: 'kubeconfig',
-        },
-      ],
-      tasks: [
-        {
-          name: 'generate-source-kubeconfig',
-          params: [
-            {
-              name: 'cluster-secret',
-              value: '$(params.source-cluster-secret)',
-            },
-            {
-              name: 'context-name',
-              value: 'source',
-            },
-          ],
-          taskRef: {
-            name: 'crane-kubeconfig-generator',
-            kind: 'ClusterTask',
-          },
-          workspaces: [
-            {
-              name: 'kubeconfig',
-              workspace: 'kubeconfig',
-            },
-          ],
-        },
-        {
-          name: 'generate-destination-kubeconfig',
-          runAfter: ['generate-source-kubeconfig'],
-          params: [
-            {
-              name: 'cluster-secret',
-              value: '$(params.destination-cluster-secret)',
-            },
-            {
-              name: 'context-name',
-              value: 'destination',
-            },
-          ],
-          taskRef: {
-            name: 'crane-kubeconfig-generator',
-            kind: 'ClusterTask',
-          },
-          workspaces: [
-            {
-              name: 'kubeconfig',
-              workspace: 'kubeconfig',
-            },
-          ],
-        },
-        {
-          name: 'export',
-          runAfter: ['generate-destination-kubeconfig'],
-          params: [
-            {
-              name: 'context',
-              value: 'source',
-            },
-            {
-              name: 'namespace',
-              value: '$(params.source-namespace)',
-            },
-          ],
-          taskRef: {
-            name: 'crane-export',
-            kind: 'ClusterTask',
-          },
-          workspaces: [
-            {
-              name: 'export',
-              workspace: 'shared-data',
-              subPath: 'export',
-            },
-            {
-              name: 'kubeconfig',
-              workspace: 'kubeconfig',
-            },
-          ],
-        },
-        {
-          name: 'transform',
-          runAfter: ['export'],
-          params: [],
-          taskRef: {
-            name: 'crane-transform',
-            kind: 'ClusterTask',
-          },
-          workspaces: [
-            {
-              name: 'export',
-              workspace: 'shared-data',
-              subPath: 'export',
-            },
-            {
-              name: 'transform',
-              workspace: 'shared-data',
-              subPath: 'transform',
-            },
-          ],
-        },
-        {
-          name: 'apply',
-          runAfter: ['transform'],
-          taskRef: {
-            name: 'crane-apply',
-            kind: 'ClusterTask',
-          },
-          workspaces: [
-            {
-              name: 'export',
-              workspace: 'shared-data',
-              subPath: 'export',
-            },
-            {
-              name: 'transform',
-              workspace: 'shared-data',
-              subPath: 'transform',
-            },
-            {
-              name: 'apply',
-              workspace: 'shared-data',
-              subPath: 'apply',
-            },
-          ],
-        },
-        {
-          name: 'kustomize-init',
-          runAfter: ['apply'],
-          params: [
-            {
-              name: 'source-namespace',
-              value: '$(params.source-namespace)',
-            },
-            {
-              name: 'namespace',
-              value: '$(context.taskRun.namespace)',
-            },
-          ],
-          taskRef: {
-            name: 'crane-kustomize-init',
-            kind: 'ClusterTask',
-          },
-          workspaces: [
-            {
-              name: 'apply',
-              workspace: 'shared-data',
-              subPath: 'apply',
-            },
-            {
-              name: 'kustomize',
-              workspace: 'shared-data',
-            },
-          ],
-        },
-        {
-          name: 'kubectl-apply-kustomize',
-          runAfter: ['kustomize-init'],
-          params: [
-            {
-              name: 'context',
-              value: 'destination',
-            },
-          ],
-          taskRef: {
-            name: 'kubectl-apply-kustomize',
-            kind: 'ClusterTask',
-          },
-          workspaces: [
-            {
-              name: 'kustomize',
-              workspace: 'shared-data',
-            },
-            {
-              name: 'kubeconfig',
-              workspace: 'kubeconfig',
-            },
-          ],
-        },
-      ],
+      tasks: [],
     },
   };
 
-  const pipelineRun: PipelineRunKind = {
+  const pipelineRunCommon: PipelineRunKind = {
     apiVersion: 'tekton.dev/v1beta1',
     kind: 'PipelineRun',
-    metadata: {
-      generateName: `${pipelineName}-`, // <--
-      namespace, // <--
-    },
     spec: {
-      ...(!startImmediately ? { status: 'PipelineRunPending' } : {}), // <--
       params: [
-        {
-          name: 'source-cluster-secret',
-          value: sourceApiSecret?.metadata.name || '', // <--
-        },
-        {
-          name: 'destination-cluster-secret',
-          value: destinationApiSecret?.metadata.name || '', // <--
-        },
-        {
-          name: 'source-namespace',
-          value: sourceNamespace, // <--
-        },
+        { name: 'source-cluster-secret', value: sourceApiSecret?.metadata.name || '' },
+        { name: 'destination-cluster-secret', value: destinationApiSecret?.metadata.name || '' },
+        { name: 'source-namespace', value: sourceNamespace },
       ],
-      workspaces: [
-        {
-          name: 'shared-data',
-          volumeClaimTemplate: {
-            spec: {
-              accessModes: ['ReadWriteOnce'],
-              resources: {
-                requests: {
-                  storage: '10Mi',
-                },
-              },
-            },
-          },
-        },
-        {
-          name: 'kubeconfig',
-          volumeClaimTemplate: {
-            spec: {
-              accessModes: ['ReadWriteOnce'],
-              resources: {
-                requests: {
-                  storage: '10Mi',
-                },
-              },
-            },
-          },
-        },
-      ],
-      pipelineRef: {
-        name: pipelineName,
-      },
     },
   };
 
-  return { pipeline, pipelineRun };
+  const workspaceVolumeClaimTemplate = {
+    spec: { accessModes: ['ReadWriteOnce'], resources: { requests: { storage: '10Mi' } } },
+  };
+
+  const tasks = getAllPipelineTasks(forms, namespace);
+
+  const stagePipeline: PipelineKind | null = isStatefulMigration
+    ? {
+        ...pipelineCommon,
+        metadata: { name: `${pipelineName}-stage`, namespace },
+        spec: {
+          ...pipelineCommon.spec,
+          workspaces: [{ name: 'kubeconfig' }],
+          tasks: [
+            tasks.generateSourceKubeconfigTask,
+            tasks.generateDestinationKubeconfigTask,
+            ...tasks.transferPvcTasks.map((task) => ({
+              ...task,
+              runAfter: ['generate-destination-kubeconfig'],
+            })),
+          ],
+        },
+      }
+    : null;
+
+  const stagePipelineRun: PipelineRunKind | null = isStatefulMigration
+    ? {
+        ...pipelineRunCommon,
+        metadata: { generateName: `${pipelineName}-stage-`, namespace },
+        spec: {
+          ...pipelineRunCommon.spec,
+          ...(!startImmediately ? { status: 'PipelineRunPending' } : {}),
+          pipelineRef: { name: `${pipelineName}-stage` },
+          workspaces: [{ name: 'kubeconfig', volumeClaimTemplate: workspaceVolumeClaimTemplate }],
+        },
+      }
+    : null;
+
+  const cutoverPipeline: PipelineKind = {
+    ...pipelineCommon,
+    metadata: { name: isStatefulMigration ? `${pipelineName}-cutover` : pipelineName, namespace },
+    spec: {
+      ...pipelineCommon.spec,
+      workspaces: [{ name: 'shared-data' }, { name: 'kubeconfig' }],
+      tasks: [
+        tasks.generateSourceKubeconfigTask,
+        tasks.generateDestinationKubeconfigTask,
+        tasks.craneExportTask,
+        ...(isStatefulMigration
+          ? [
+              tasks.quiesceDeploymentsTask,
+              tasks.quiesceDeploymentConfigsTask,
+              tasks.quiesceStatefulSetsTask,
+              tasks.quiesceJobsTask,
+              ...tasks.transferPvcTasks.map((task) => ({
+                ...task,
+                runAfter: [
+                  'quiesce-deployments',
+                  'quiesce-deploymentconfigs',
+                  'quiesce-statefulsets',
+                  'quiesce-jobs',
+                ],
+              })),
+              tasks.chownTask,
+            ]
+          : []),
+        tasks.craneTransformTask,
+        tasks.craneApplyTask,
+        tasks.kustomizeInitTask,
+        tasks.kubectlApplyKustomizeTask,
+      ],
+    },
+  };
+
+  const cutoverPipelineRun: PipelineRunKind = {
+    ...pipelineRunCommon,
+    metadata: {
+      generateName: isStatefulMigration ? `${pipelineName}-cutover-` : `${pipelineName}-`,
+      namespace,
+    },
+    spec: {
+      ...pipelineRunCommon.spec,
+      ...(isStatefulMigration || !startImmediately ? { status: 'PipelineRunPending' } : {}),
+      pipelineRef: { name: isStatefulMigration ? `${pipelineName}-cutover` : pipelineName },
+      workspaces: [
+        { name: 'shared-data', volumeClaimTemplate: workspaceVolumeClaimTemplate },
+        { name: 'kubeconfig', volumeClaimTemplate: workspaceVolumeClaimTemplate },
+      ],
+    },
+  };
+
+  return { stagePipeline, stagePipelineRun, cutoverPipeline, cutoverPipelineRun };
 };

--- a/src/api/pipelineTaskHelpers.ts
+++ b/src/api/pipelineTaskHelpers.ts
@@ -161,7 +161,7 @@ export const getAllPipelineTasks = (forms: ImportWizardFormState, namespace: str
   const chownTask = {
     name: 'chown',
     params: [
-      { name: 'pvcs', value: selectedPVCs.map((pvc) => pvc.metadata?.name) },
+      { name: 'pvcs', value: selectedPVCs.map((pvc) => pvc.metadata?.name).join(',') },
       { name: 'namespace', value: '$(params.source-namespace)' },
       { name: 'context', value: 'destination' },
     ],

--- a/src/api/pipelineTaskHelpers.ts
+++ b/src/api/pipelineTaskHelpers.ts
@@ -163,7 +163,7 @@ export const getAllPipelineTasks = (forms: ImportWizardFormState, namespace: str
     params: [
       { name: 'pvcs', value: selectedPVCs.map((pvc) => pvc.metadata?.name) },
       { name: 'namespace', value: '$(params.source-namespace)' },
-      { name: 'context', value: '$(params.context)' },
+      { name: 'context', value: 'destination' },
     ],
     runAfter: ['transfer-pvc'],
     taskRef: { kind: 'ClusterTask', name: 'crane-ownership-change' },

--- a/src/api/pipelineTaskHelpers.ts
+++ b/src/api/pipelineTaskHelpers.ts
@@ -1,0 +1,187 @@
+import { ImportWizardFormState } from 'src/components/ImportWizard/ImportWizardFormContext';
+import { PipelineTask } from './types/pipelines-plugin';
+
+export const getAllPipelineTasks = (forms: ImportWizardFormState, namespace: string) => {
+  const { sourceNamespace } = forms.sourceClusterProject.values;
+  const { selectedPVCs } = forms.pvcSelect.values;
+  const { editValuesByPVC } = forms.pvcEdit.values;
+
+  const generateSourceKubeconfigTask: PipelineTask = {
+    name: 'generate-source-kubeconfig',
+    params: [
+      { name: 'cluster-secret', value: '$(params.source-cluster-secret)' },
+      { name: 'context-name', value: 'source' },
+    ],
+    taskRef: { name: 'crane-kubeconfig-generator', kind: 'ClusterTask' },
+    workspaces: [{ name: 'kubeconfig', workspace: 'kubeconfig' }],
+  };
+
+  const generateDestinationKubeconfigTask: PipelineTask = {
+    name: 'generate-destination-kubeconfig',
+    runAfter: ['generate-source-kubeconfig'],
+    params: [
+      { name: 'cluster-secret', value: '$(params.destination-cluster-secret)' },
+      { name: 'context-name', value: 'destination' },
+    ],
+    taskRef: { name: 'crane-kubeconfig-generator', kind: 'ClusterTask' },
+    workspaces: [{ name: 'kubeconfig', workspace: 'kubeconfig' }],
+  };
+
+  const craneExportTask: PipelineTask = {
+    name: 'export',
+    params: [
+      { name: 'context', value: 'source' },
+      { name: 'namespace', value: '$(params.source-namespace)' },
+    ],
+    runAfter: ['generate-destination-kubeconfig'],
+    taskRef: { kind: 'ClusterTask', name: 'crane-export' },
+    workspaces: [
+      { name: 'export', subPath: 'export', workspace: 'shared-data' },
+      { name: 'kubeconfig', workspace: 'kubeconfig' },
+    ],
+  };
+
+  const craneTransformTask: PipelineTask = {
+    name: 'transform',
+    runAfter: ['export'],
+    params: [],
+    taskRef: { name: 'crane-transform', kind: 'ClusterTask' },
+    workspaces: [
+      { name: 'export', workspace: 'shared-data', subPath: 'export' },
+      { name: 'transform', workspace: 'shared-data', subPath: 'transform' },
+    ],
+  };
+
+  const craneApplyTask: PipelineTask = {
+    name: 'apply',
+    runAfter: ['transform'],
+    taskRef: { name: 'crane-apply', kind: 'ClusterTask' },
+    workspaces: [
+      { name: 'export', workspace: 'shared-data', subPath: 'export' },
+      { name: 'transform', workspace: 'shared-data', subPath: 'transform' },
+      { name: 'apply', workspace: 'shared-data', subPath: 'apply' },
+    ],
+  };
+
+  const kustomizeInitTask: PipelineTask = {
+    name: 'kustomize-init',
+    runAfter: ['apply'],
+    params: [
+      { name: 'source-namespace', value: '$(params.source-namespace)' },
+      { name: 'namespace', value: '$(context.taskRun.namespace)' },
+    ],
+    taskRef: { name: 'crane-kustomize-init', kind: 'ClusterTask' },
+    workspaces: [
+      { name: 'apply', workspace: 'shared-data', subPath: 'apply' },
+      { name: 'kustomize', workspace: 'shared-data' },
+    ],
+  };
+
+  const kubectlApplyKustomizeTask: PipelineTask = {
+    name: 'kubectl-apply-kustomize',
+    runAfter: ['kustomize-init'],
+    params: [{ name: 'context', value: 'destination' }],
+    taskRef: { name: 'kubectl-apply-kustomize', kind: 'ClusterTask' },
+    workspaces: [
+      { name: 'kustomize', workspace: 'shared-data' },
+      { name: 'kubeconfig', workspace: 'kubeconfig' },
+    ],
+  };
+
+  const quiesceDeploymentsTask: PipelineTask = {
+    name: 'quiesce-deployments',
+    params: [
+      { name: 'context', value: 'source' },
+      { name: 'namespace', value: '$(params.source-namespace)' },
+      { name: 'resource-type', value: 'deployment' },
+    ],
+    runAfter: ['export'],
+    taskRef: { kind: 'ClusterTask', name: 'kubectl-scale-down' },
+    workspaces: [{ name: 'kubeconfig', workspace: 'kubeconfig' }],
+  };
+
+  const quiesceDeploymentConfigsTask: PipelineTask = {
+    name: 'quiesce-deploymentconfigs',
+    params: [
+      { name: 'context', value: 'source' },
+      { name: 'namespace', value: '$(params.source-namespace)' },
+      { name: 'resource-type', value: 'deploymentconfig' },
+    ],
+    runAfter: ['export'],
+    taskRef: { kind: 'ClusterTask', name: 'kubectl-scale-down' },
+    workspaces: [{ name: 'kubeconfig', workspace: 'kubeconfig' }],
+  };
+
+  const quiesceStatefulSetsTask: PipelineTask = {
+    name: 'quiesce-statefulsets',
+    params: [
+      { name: 'context', value: 'source' },
+      { name: 'namespace', value: '$(params.source-namespace)' },
+      { name: 'resource-type', value: 'statefulset' },
+    ],
+    runAfter: ['export'],
+    taskRef: { kind: 'ClusterTask', name: 'kubectl-scale-down' },
+    workspaces: [{ name: 'kubeconfig', workspace: 'kubeconfig' }],
+  };
+
+  const quiesceJobsTask: PipelineTask = {
+    name: 'quiesce-jobs',
+    params: [
+      { name: 'context', value: 'source' },
+      { name: 'namespace', value: '$(params.source-namespace)' },
+      { name: 'resource-type', value: 'job' },
+    ],
+    runAfter: ['export'],
+    taskRef: { kind: 'ClusterTask', name: 'kubectl-scale-down' },
+    workspaces: [{ name: 'kubeconfig', workspace: 'kubeconfig' }],
+  };
+
+  const transferPvcTasks: PipelineTask[] = selectedPVCs.map((pvc) => {
+    const editValues = editValuesByPVC[pvc.metadata?.name || ''];
+    const { targetPvcName, storageClass, capacity, verifyCopy } = editValues; // TODO where to put verifyCopy?
+    return {
+      name: 'transfer-pvc',
+      params: [
+        { name: 'source-context', value: 'source' },
+        { name: 'source-namespace', value: sourceNamespace },
+        { name: 'source-pvc-name', value: pvc.metadata?.name },
+        { name: 'dest-context', value: 'destination' },
+        { name: 'dest-pvc-name', value: targetPvcName },
+        { name: 'dest-namespace', value: namespace },
+        { name: 'dest-storage-class-name', value: storageClass },
+        { name: 'dest-pvc-capacity', value: capacity },
+        { name: 'endpoint-type', value: 'route' },
+      ],
+      taskRef: { kind: 'ClusterTask', name: 'crane-transfer-pvc' },
+      workspaces: [{ name: 'kubeconfig', workspace: 'kubeconfig' }],
+    };
+  });
+
+  const chownTask = {
+    name: 'chown',
+    params: [
+      { name: 'pvcs', value: selectedPVCs.map((pvc) => pvc.metadata?.name) },
+      { name: 'namespace', value: '$(params.source-namespace)' },
+      { name: 'context', value: '$(params.context)' },
+    ],
+    runAfter: ['transfer-pvc'],
+    taskRef: { kind: 'ClusterTask', name: 'crane-ownership-change' },
+    workspaces: [{ name: 'kubeconfig', workspace: 'kubeconfig' }],
+  };
+
+  return {
+    generateSourceKubeconfigTask,
+    generateDestinationKubeconfigTask,
+    craneExportTask,
+    craneTransformTask,
+    craneApplyTask,
+    kustomizeInitTask,
+    kubectlApplyKustomizeTask,
+    quiesceDeploymentsTask,
+    quiesceDeploymentConfigsTask,
+    quiesceStatefulSetsTask,
+    quiesceJobsTask,
+    transferPvcTasks,
+    chownTask,
+  };
+};

--- a/src/api/pipelineTaskHelpers.ts
+++ b/src/api/pipelineTaskHelpers.ts
@@ -139,6 +139,7 @@ export const getAllPipelineTasks = (forms: ImportWizardFormState, namespace: str
   const transferPvcTasks: PipelineTask[] = selectedPVCs.map((pvc) => {
     const editValues = editValuesByPVC[pvc.metadata?.name || ''];
     const { targetPvcName, storageClass, capacity, verifyCopy } = editValues; // TODO where to put verifyCopy?
+    console.log('TODO: use verifyCopy flag!', pvc.metadata?.name, verifyCopy);
     return {
       name: 'transfer-pvc',
       params: [

--- a/src/common/schema.ts
+++ b/src/common/schema.ts
@@ -60,12 +60,13 @@ export const yamlSchema = yup.string().test({
   },
 });
 
-// TODO validate that the pipeline name doesn't exist already with -stage, -cutover suffixes either (if necessary?)
-export const getPipelineNameSchema = (pipelinesWatch: ReturnType<typeof useWatchPipelines>) => {
+export const getPipelineNameSchema = (
+  pipelinesWatch: ReturnType<typeof useWatchPipelines>,
+  isStatefulMigration: boolean,
+) => {
   // k8s resource name length is limited to 63 characters.
-  // We will use it as a prefix for generateName, which will add 6 characters.
-  // We also may put a suffix of "-stage", "-cutover", or "-rollback" on the name, which adds up to 9 characters.
-  const maxLength = 48; // 63 - 6 - 9
+  let maxLength = 63 - 6; // We will use it as a prefix for generateName, which will add 6 characters.
+  if (isStatefulMigration) maxLength -= 8; // We also add a suffix "-stage" or "-cutover", which adds up to 8 characters.
   return dnsLabelNameSchema
     .label('Pipeline name')
     .required()
@@ -75,6 +76,11 @@ export const getPipelineNameSchema = (pipelinesWatch: ReturnType<typeof useWatch
       'A pipeline with this name already exists',
       (value) =>
         !pipelinesWatch.loaded ||
-        !pipelinesWatch.data?.find((pipeline) => pipeline.metadata?.name === value),
+        !pipelinesWatch.data?.find(
+          (pipeline) =>
+            pipeline.metadata?.name === value ||
+            (isStatefulMigration &&
+              [`${value}-stage`, `${value}-cutover`].includes(pipeline.metadata?.name || '')),
+        ),
     );
 };

--- a/src/components/ImportWizard/ImportWizardFormContext.tsx
+++ b/src/components/ImportWizard/ImportWizardFormContext.tsx
@@ -155,7 +155,7 @@ export const usePVCEditRowFormState = (existingValues: PVCEditRowFormValues) => 
     targetPvcName: useFormField(
       targetPvcName,
       dnsLabelNameSchema.label('Target PVC name').required(),
-    ),
+    ), // TODO validate that it doesn't exist (oops)
     storageClass: useFormField(storageClass, dnsLabelNameSchema.label('Storage class').required()),
     capacity: useFormField(capacity, capacitySchema.label('Capacity').required()),
     verifyCopy: useFormField(verifyCopy, yup.boolean().label('Verify copy').required()),

--- a/src/components/ImportWizard/ImportWizardFormContext.tsx
+++ b/src/components/ImportWizard/ImportWizardFormContext.tsx
@@ -137,8 +137,16 @@ export const useImportWizardFormState = () => {
     }),
     review: useFormState({
       destinationApiSecret: useFormField<OAuthSecret | null>(null, yup.mixed()),
-      pipelineYaml: useFormField('', yamlSchema.label('Pipeline').required()),
-      pipelineRunYaml: useFormField('', yamlSchema.label('PipelineRun').required()),
+      stagePipelineYaml: useFormField('', yamlSchema.label('Pipeline (stage)').required()),
+      stagePipelineRunYaml: useFormField('', yamlSchema.label('PipelineRun (stage)').required()),
+      cutoverPipelineYaml: useFormField(
+        '',
+        yamlSchema.label(`Pipeline${isStatefulMigration ? ' (cutover)' : ''}`).required(),
+      ),
+      cutoverPipelineRunYaml: useFormField(
+        '',
+        yamlSchema.label(`PipelineRun${isStatefulMigration ? ' (cutover)' : ''}`).required(),
+      ),
     }),
   };
 };

--- a/src/components/ImportWizard/ImportWizardFormContext.tsx
+++ b/src/components/ImportWizard/ImportWizardFormContext.tsx
@@ -99,6 +99,12 @@ export const useImportWizardFormState = () => {
     credentialsAreValid,
   ).label('Project name');
 
+  const selectedPVCsField = useFormField<PersistentVolumeClaim[]>([], yup.array(), {
+    onChange: onSelectedPVCsChange,
+  });
+
+  const isStatefulMigration = selectedPVCsField.value.length > 0;
+
   return {
     sourceClusterProject: useFormState(
       {
@@ -116,16 +122,17 @@ export const useImportWizardFormState = () => {
       },
     ),
     pvcSelect: useFormState({
-      selectedPVCs: useFormField<PersistentVolumeClaim[]>([], yup.array(), {
-        onChange: onSelectedPVCsChange,
-      }),
+      selectedPVCs: selectedPVCsField,
     }),
     pvcEdit: useFormState({
       isEditModeByPVC: isEditModeByPVCField,
       editValuesByPVC: editValuesByPVCField,
     }),
     pipelineSettings: useFormState({
-      pipelineName: useFormField('', getPipelineNameSchema(useWatchPipelines())),
+      pipelineName: useFormField(
+        '',
+        getPipelineNameSchema(useWatchPipelines(), isStatefulMigration),
+      ),
       startImmediately: useFormField(false, yup.boolean().required()),
     }),
     review: useFormState({

--- a/src/components/ImportWizard/PipelineSettingsStep.tsx
+++ b/src/components/ImportWizard/PipelineSettingsStep.tsx
@@ -6,20 +6,27 @@ import { ImportWizardFormContext } from './ImportWizardFormContext';
 import { ValidatedTextInput } from '@konveyor/lib-ui';
 
 export const PipelineSettingsStep: React.FunctionComponent = () => {
-  const form = React.useContext(ImportWizardFormContext).pipelineSettings;
+  const forms = React.useContext(ImportWizardFormContext);
+  const form = forms.pipelineSettings;
+  const isStatefulMigration = forms.pvcSelect.values.selectedPVCs.length > 0;
   return (
     <>
       <TextContent className={spacing.mbMd}>
         <Text component="h2">Migration pipeline settings</Text>
         <Text component="p">
-          Enter a name for the OpenShift pipeline that will drive the tasks required to migrate your
-          application.
+          {isStatefulMigration
+            ? 'Enter a name prefix for the OpenShift pipelines that will drive the tasks required to migrate your application.'
+            : 'Enter a name for the OpenShift pipeline that will drive the tasks required to migrate your application.'}
         </Text>
       </TextContent>
       <Form isWidthLimited>
         <ValidatedTextInput field={form.fields.pipelineName} isRequired fieldId="pipeline-name" />
         <Checkbox
-          label="Start the pipeline immediately"
+          label={
+            isStatefulMigration
+              ? 'Start the stage pipeline immediately'
+              : 'Start the pipeline immediately'
+          }
           id="start-immediately-checkbox"
           isChecked={form.values.startImmediately}
           onChange={form.fields.startImmediately.setValue}

--- a/src/components/ImportWizard/ReviewStep.tsx
+++ b/src/components/ImportWizard/ReviewStep.tsx
@@ -62,7 +62,7 @@ export const ReviewStep: React.FunctionComponent = () => {
           setSelected={setSelectedEditorKey}
           selectedLabel={selectedEditorFormField.schema.describe().label}
           id="editor-select"
-          toggleProps={{ style: { width: '150px' } }}
+          toggleProps={{ style: { width: '200px' } }}
         >
           <MenuContent>
             <MenuList>

--- a/src/components/ImportWizard/ReviewStep.tsx
+++ b/src/components/ImportWizard/ReviewStep.tsx
@@ -19,25 +19,29 @@ import { ImportWizardFormContext, ImportWizardFormState } from './ImportWizardFo
 
 type YamlFieldKey = keyof Pick<
   ImportWizardFormState['review']['fields'],
-  'pipelineYaml' | 'pipelineRunYaml'
+  'stagePipelineYaml' | 'stagePipelineRunYaml' | 'cutoverPipelineYaml' | 'cutoverPipelineRunYaml'
 >;
-const YAML_FIELD_KEYS: YamlFieldKey[] = ['pipelineYaml', 'pipelineRunYaml'];
 
 export const ReviewStep: React.FunctionComponent = () => {
   const forms = React.useContext(ImportWizardFormContext);
 
+  const isStatefulMigration = forms.pvcSelect.values.selectedPVCs.length > 0;
+  const yamlFieldKeys: YamlFieldKey[] = isStatefulMigration
+    ? ['stagePipelineYaml', 'stagePipelineRunYaml', 'cutoverPipelineYaml', 'cutoverPipelineRunYaml']
+    : ['cutoverPipelineYaml', 'cutoverPipelineRunYaml'];
+
   // TODO warn somehow if the user is going to override their manual edits here when they go to another step (use isTouched)? not sure how to do that if they use canJumpTo
 
-  const [selectedEditorKey, setSelectedEditorKey] = React.useState<YamlFieldKey>('pipelineYaml');
+  const [selectedEditorKey, setSelectedEditorKey] =
+    React.useState<YamlFieldKey>('cutoverPipelineYaml');
   const selectedEditorFormField = forms.review.fields[selectedEditorKey];
 
   const editorContainerRef = React.useRef<HTMLDivElement>(null);
   const editorContainerHeight = useSize(editorContainerRef)[1];
 
-  const yamlErrors = [
-    forms.review.fields.pipelineYaml.error?.message,
-    forms.review.fields.pipelineRunYaml.error?.message,
-  ].filter((err) => !!err);
+  const yamlErrors = yamlFieldKeys
+    .map((fieldKey) => forms.review.fields[fieldKey].error?.message)
+    .filter((err) => !!err);
 
   // TODO on smaller screen sizes and when errors show, this flex layout turns into columns, we need a better fix for the editor height
   // TODO take a look at onEditorDidMount in the PF examples, what's going on with that, how is it implemented?
@@ -62,7 +66,7 @@ export const ReviewStep: React.FunctionComponent = () => {
         >
           <MenuContent>
             <MenuList>
-              {YAML_FIELD_KEYS.map((fieldKey) => (
+              {yamlFieldKeys.map((fieldKey) => (
                 <MenuItem key={fieldKey} itemId={fieldKey}>
                   {forms.review.fields[fieldKey].schema.describe().label}
                 </MenuItem>

--- a/src/components/ImportWizard/ReviewStep.tsx
+++ b/src/components/ImportWizard/ReviewStep.tsx
@@ -53,7 +53,9 @@ export const ReviewStep: React.FunctionComponent = () => {
       <TextContent className={spacing.mbMd}>
         <Text component="h2">Review</Text>
         <Text component="p">
-          Review the YAML for the OpenShift Pipeline and PipelineRun that will be created.
+          Review the YAML for the OpenShift{' '}
+          {isStatefulMigration ? 'Pipelines and PipelineRuns' : 'Pipeline and PipelineRun'} that
+          will be created.
         </Text>
       </TextContent>
       <FlexItem>

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,8 @@
-import { K8sResourceCommon, ObjectReference } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  K8sResourceCommon,
+  ObjectReference,
+  OwnerReference,
+} from '@openshift-console/dynamic-plugin-sdk';
 import { PersistentVolumeClaim } from 'src/api/types/PersistentVolume';
 
 export const isSameResource = (
@@ -26,4 +30,15 @@ export const getObjectRef = (resource: K8sResourceCommon): ObjectReference => ({
   name: resource.metadata?.name,
   namespace: resource.metadata?.namespace,
   uid: resource.metadata?.uid,
+});
+
+export const attachOwnerReference = <T extends K8sResourceCommon>(
+  resource: T,
+  ownerRef: ObjectReference,
+) => ({
+  ...resource,
+  metadata: {
+    ...resource.metadata,
+    ownerReferences: [...(resource.metadata?.ownerReferences || []), ownerRef as OwnerReference],
+  },
 });

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -11,14 +11,16 @@ interface Configuration extends WebpackConfiguration {
 }
 
 const config: Configuration = {
-  mode: 'development',
+  mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
   // No regular entry points. The remote container entry is handled by ConsoleRemotePlugin.
   entry: {},
   context: path.resolve(__dirname, 'src'),
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: '[name]-bundle.js',
-    chunkFilename: '[name]-chunk.js',
+    filename:
+      process.env.NODE_ENV === 'production' ? '[name]-bundle-[hash].min.js' : '[name]-bundle.js',
+    chunkFilename:
+      process.env.NODE_ENV === 'production' ? '[name]-chunk-[chunkhash].min.js' : '[name]-chunk.js',
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.jsx'],
@@ -78,17 +80,9 @@ const config: Configuration = {
   ],
   devtool: 'source-map',
   optimization: {
-    chunkIds: 'named',
-    minimize: false, // TODO look into why this is false in the template. enabling it would remove dead code (mock data in prod)
+    chunkIds: process.env.NODE_ENV === 'production' ? 'deterministic' : 'named',
+    minimize: process.env.NODE_ENV === 'production',
   },
 };
-
-if (process.env.NODE_ENV === 'production') {
-  config.mode = 'production';
-  config.output.filename = '[name]-bundle-[hash].min.js';
-  config.output.chunkFilename = '[name]-chunk-[chunkhash].min.js';
-  config.optimization.chunkIds = 'deterministic';
-  config.optimization.minimize = true;
-}
 
 export default config;


### PR DESCRIPTION
* Factors out PipelineTask definitions into their own `pipelineTaskHelpers.ts` file for reuse.
  * That file contains one big `getAllPipelineTasks` function which allows tasks to be defined with the wizard form values in scope.
* Replaces static Pipeline/PipelineRun definition in `formsToTektonResources` with logic to generate them dynamically based on whether we are migrating PVCs.
  * If the user selected no PVCs, the YAML will be generated as it is today and the user-provided pipeline name will be used.
  * If the user selected at least one PVC:
    * An additional Pipeline(Run) pair will be created for stage.
    * Pipeline(Run)s will be generated with `-stage` and `-cutover` suffixes on the name.
    * Additional tasks for quiesce, PVC transfer, and chown will be included.
* The Review step of the wizard adapts to include the stage/cutover pipelines in its YAML editor if relevant.
* When the resources are created, the cutover pipeline is used as the ownerReference of the other 3 resources (cutover pipelinerun, stage pipeline and stage pipelinerun).

Note: I still need to validate that the user-entered target PVC names are unique / don't already exist. Missed that when implementing the Edit PVCs step.