### PR TITLE
Change wizard title from 'Smart Import' to 'Import application'

### DIFF
--- a/src/components/ImportPage.tsx
+++ b/src/components/ImportPage.tsx
@@ -25,7 +25,7 @@ const ImportPage: React.FunctionComponent<PipelineWizardPageProps> = ({
       <NamespaceContext.Provider value={namespace}>
         <Page>
           <PageSection variant="light">
-            <Title headingLevel="h1">Smart Import Wizard Name</Title>
+            <Title headingLevel="h1">Import application</Title>
           </PageSection>
           <PageSection variant="light" type="wizard">
             <ImportWizard />


### PR DESCRIPTION
Nobody can decide on this name, so I'm just changing it to a temporary one that is less bad