### PR TITLE
Update cutover pipeline to consider quiesce task in case of stateful migrations

### DIFF
--- a/src/api/pipelineHelpers.ts
+++ b/src/api/pipelineHelpers.ts
@@ -115,7 +115,12 @@ export const formsToTektonResources = (
         tasks.craneTransformTask,
         tasks.craneApplyTask,
         tasks.kustomizeInitTask,
-        tasks.kubectlApplyKustomizeTask,
+        isStatefulMigration
+          ? {
+              ...tasks.kubectlApplyKustomizeTask,
+              runAfter: ['chown', 'kustomize-init'],
+            }
+          : tasks.kubectlApplyKustomizeTask,
       ],
     },
   };


### PR DESCRIPTION
Conditionally updates `runAfter` clause of the last task