### PR TITLE
Warn the user before they lose unsaved changes

### DIFF
--- a/src/common/components/ConfirmModal.tsx
+++ b/src/common/components/ConfirmModal.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { Modal, Stack, Flex, Button, ModalProps } from '@patternfly/react-core';
+import { ResolvedQuery } from '@konveyor/lib-ui';
+import { UseMutationResult, UseQueryResult } from 'react-query';
+
+// TODO export this from lib-ui? part of ResolvedQueries
+export type UnknownResult = Pick<
+  UseQueryResult<unknown>,
+  'isError' | 'isLoading' | 'isIdle' | 'error'
+>;
+
+// TODO export this from lib-ui? part of ResolvedQueries
+export type UnknownMutationResult = Pick<
+  UseMutationResult<unknown>,
+  'isError' | 'isLoading' | 'isIdle' | 'error' | 'reset'
+>;
+
+// TODO lib-ui candidate copied from forklift-ui
+
+export interface IConfirmModalProps {
+  variant?: ModalProps['variant'];
+  isOpen: boolean;
+  toggleOpen: () => void;
+  mutateFn: () => void;
+  mutateResult?: UnknownMutationResult;
+  title: string;
+  body: React.ReactNode;
+  confirmButtonText: string;
+  cancelButtonText?: string;
+  confirmButtonDisabled?: boolean;
+  errorText?: string;
+}
+
+export const ConfirmModal: React.FunctionComponent<IConfirmModalProps> = ({
+  variant = 'small',
+  isOpen,
+  toggleOpen,
+  mutateFn,
+  mutateResult,
+  title,
+  body,
+  confirmButtonText,
+  confirmButtonDisabled = false,
+  cancelButtonText = 'Cancel',
+  errorText = 'Error performing action',
+}: IConfirmModalProps) =>
+  isOpen ? (
+    <Modal
+      variant={variant}
+      title={title}
+      isOpen
+      onClose={toggleOpen}
+      footer={
+        <Stack hasGutter>
+          {mutateResult ? (
+            <ResolvedQuery result={mutateResult} errorTitle={errorText} spinnerMode="inline" />
+          ) : null}
+          <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+            <Button
+              id="modal-confirm-button"
+              key="confirm"
+              variant="primary"
+              onClick={mutateFn}
+              isDisabled={mutateResult?.isLoading || confirmButtonDisabled}
+            >
+              {confirmButtonText}
+            </Button>
+            <Button
+              id="modal-cancel-button"
+              key="cancel"
+              variant="link"
+              onClick={toggleOpen}
+              isDisabled={mutateResult?.isLoading}
+            >
+              {cancelButtonText}
+            </Button>
+          </Flex>
+        </Stack>
+      }
+    >
+      {body}
+    </Modal>
+  ) : null;

--- a/src/common/components/RouteGuard.tsx
+++ b/src/common/components/RouteGuard.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import { useHistory } from 'react-router';
+import { UnregisterCallback } from 'history';
+import { ConfirmModal } from './ConfirmModal';
+
+// TODO lib-ui candidate?
+
+const blockUnload = (event: BeforeUnloadEvent) => {
+  // The beforeunload event is weird in different browsers.
+  // See: https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload#example
+  event.preventDefault();
+  event.returnValue = '';
+};
+
+interface IRouteGuard {
+  when: boolean;
+  title: string;
+  message: string | JSX.Element;
+  okText?: string;
+  cancelText?: string;
+}
+
+export const RouteGuard: React.FunctionComponent<IRouteGuard> = ({
+  when,
+  title,
+  message,
+  okText = 'OK',
+  cancelText = 'Cancel',
+}) => {
+  const history = useHistory();
+  const [showRouteGuard, setShowRouteGuard] = React.useState(when);
+  const [currentPath, setCurrentPath] = React.useState('');
+
+  const unblockFnRef = React.useRef<UnregisterCallback | null>(null);
+  const unblock = () => {
+    if (unblockFnRef.current) {
+      unblockFnRef.current();
+      unblockFnRef.current = null;
+    }
+  };
+
+  React.useEffect(() => {
+    if (when) {
+      // When browser history routing happens (clicking links, back/forward) we can handle it with our custom modal.
+      unblockFnRef.current = history.block((prompt) => {
+        setCurrentPath(prompt.pathname);
+        setShowRouteGuard(true);
+        return false;
+      });
+      // When the page is being unloaded (closing or reloading tab), we have to trigger a native JS confirm dialog.
+      window.addEventListener('beforeunload', blockUnload);
+    }
+    return () => {
+      unblock();
+      window.removeEventListener('beforeunload', blockUnload);
+    };
+  }, [history, when]);
+
+  const handleOk = React.useCallback(() => {
+    unblock();
+    history.push(currentPath);
+  }, [currentPath, history]);
+
+  const handleCancel = React.useCallback(() => setShowRouteGuard(false), []);
+
+  return (
+    <ConfirmModal
+      title={title}
+      isOpen={showRouteGuard}
+      toggleOpen={handleCancel}
+      mutateFn={handleOk}
+      cancelButtonText={cancelText}
+      confirmButtonText={okText}
+      body={message}
+    />
+  );
+};

--- a/src/components/ImportWizard/ImportWizard.tsx
+++ b/src/components/ImportWizard/ImportWizard.tsx
@@ -31,6 +31,7 @@ import { useCreateTektonResourcesMutation } from 'src/api/queries/pipelines';
 import './ImportWizard.css';
 import { getYamlFieldKeys } from './helpers';
 import { ConfirmModal } from 'src/common/components/ConfirmModal';
+import { RouteGuard } from 'src/common/components/RouteGuard';
 
 enum StepId {
   SourceClusterProject = 0,
@@ -154,6 +155,11 @@ export const ImportWizard: React.FunctionComponent = () => {
 
   return (
     <ImportWizardFormContext.Provider value={forms}>
+      <RouteGuard
+        when={forms.isSomeFormDirty && createTektonResourcesMutation.status === 'idle'}
+        title="Leave this page?"
+        message="All unsaved changes will be lost."
+      />
       <Wizard
         id="crane-import-wizard"
         steps={[
@@ -235,7 +241,9 @@ export const ImportWizard: React.FunctionComponent = () => {
             <WizardContextConsumer>
               {({ activeStep, onNext, onBack, onClose }) => {
                 const onFinalStep = activeStep.id === StepId.Review;
-                const isNextDisabled = !canMoveToStep(nextVisibleStep(activeStep.id as StepId));
+                const isNextDisabled =
+                  !canMoveToStep(nextVisibleStep(activeStep.id as StepId)) ||
+                  createTektonResourcesMutation.status === 'loading';
                 const isBackDisabled = !canMoveToStep(prevVisibleStep(activeStep.id as StepId));
 
                 const onBackClick = () => {

--- a/src/components/ImportWizard/ImportWizard.tsx
+++ b/src/components/ImportWizard/ImportWizard.tsx
@@ -112,10 +112,10 @@ export const ImportWizard: React.FunctionComponent = () => {
     if (prevStep.prevId === StepId.Review) {
       configureDestinationSecretMutation.reset();
       createTektonResourcesMutation.reset();
-      forms.review.fields.stagePipelineYaml.clear();
-      forms.review.fields.stagePipelineRunYaml.clear();
-      forms.review.fields.cutoverPipelineYaml.clear();
-      forms.review.fields.cutoverPipelineRunYaml.clear();
+      forms.review.fields.stagePipelineYaml.reinitialize('');
+      forms.review.fields.stagePipelineRunYaml.reinitialize('');
+      forms.review.fields.cutoverPipelineYaml.reinitialize('');
+      forms.review.fields.cutoverPipelineRunYaml.reinitialize('');
     }
   };
 
@@ -284,7 +284,10 @@ export const ImportWizard: React.FunctionComponent = () => {
                       toggleOpen={() =>
                         setIsResetYamlConfirmModalOpen(!isResetYamlConfirmModalOpen)
                       }
-                      mutateFn={onBack}
+                      mutateFn={() => {
+                        setIsResetYamlConfirmModalOpen(false);
+                        onBack();
+                      }}
                       confirmButtonText="Discard"
                       body="Moving back through the wizard will discard the changes you have made to the YAML on this step."
                     />

--- a/src/components/ImportWizard/ImportWizardFormContext.tsx
+++ b/src/components/ImportWizard/ImportWizardFormContext.tsx
@@ -115,7 +115,7 @@ export const useImportWizardFormState = () => {
     ? `${pipelineNameField.value}-cutover`
     : pipelineNameField.value;
 
-  return {
+  const forms = {
     sourceClusterProject: useFormState(
       {
         apiUrl: apiUrlField,
@@ -157,6 +157,11 @@ export const useImportWizardFormState = () => {
         yamlSchema.label(`PipelineRun (${cutoverPipelineName})`).required(),
       ),
     }),
+  };
+
+  return {
+    ...forms,
+    isSomeFormDirty: Object.values(forms).some((form) => form.isDirty),
   };
 };
 

--- a/src/components/ImportWizard/ReviewStep.tsx
+++ b/src/components/ImportWizard/ReviewStep.tsx
@@ -16,15 +16,11 @@ import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { SimpleSelectMenu } from 'src/common/components/SimpleSelectMenu';
-import { ImportWizardFormContext, ImportWizardFormState } from './ImportWizardFormContext';
+import { ImportWizardFormContext } from './ImportWizardFormContext';
 import { yamlToTektonResources } from 'src/api/pipelineHelpers';
 import { PipelineVisualizationWrapper } from 'src/common/components/PipelineVisualizationWrapper';
 import { columnNames as pvcColumnNames } from './PVCEditStep';
-
-type YamlFieldKey = keyof Pick<
-  ImportWizardFormState['review']['fields'],
-  'stagePipelineYaml' | 'stagePipelineRunYaml' | 'cutoverPipelineYaml' | 'cutoverPipelineRunYaml'
->;
+import { getYamlFieldKeys, YamlFieldKey } from './helpers';
 
 export const ReviewStep: React.FunctionComponent = () => {
   const forms = React.useContext(ImportWizardFormContext);
@@ -40,9 +36,7 @@ export const ReviewStep: React.FunctionComponent = () => {
 
   const [isAdvancedMode, setIsAdvancedMode] = React.useState(false);
 
-  const yamlFieldKeys: YamlFieldKey[] = isStatefulMigration
-    ? ['stagePipelineYaml', 'stagePipelineRunYaml', 'cutoverPipelineYaml', 'cutoverPipelineRunYaml']
-    : ['cutoverPipelineYaml', 'cutoverPipelineRunYaml'];
+  const yamlFieldKeys = getYamlFieldKeys(isStatefulMigration);
 
   const [selectedEditorKey, setSelectedEditorKey] =
     React.useState<YamlFieldKey>('cutoverPipelineYaml');

--- a/src/components/ImportWizard/helpers.ts
+++ b/src/components/ImportWizard/helpers.ts
@@ -1,0 +1,11 @@
+import { ImportWizardFormState } from './ImportWizardFormContext';
+
+export type YamlFieldKey = keyof Pick<
+  ImportWizardFormState['review']['fields'],
+  'stagePipelineYaml' | 'stagePipelineRunYaml' | 'cutoverPipelineYaml' | 'cutoverPipelineRunYaml'
+>;
+
+export const getYamlFieldKeys = (isStatefulMigration: boolean): YamlFieldKey[] =>
+  isStatefulMigration
+    ? ['stagePipelineYaml', 'stagePipelineRunYaml', 'cutoverPipelineYaml', 'cutoverPipelineRunYaml']
+    : ['cutoverPipelineYaml', 'cutoverPipelineRunYaml'];


### PR DESCRIPTION
* If the user has touched the YAML editor on the Review step, wizard nav is blocked and clicking the Back button will open a warning asking if the user wants to discard those changes.
* If any form fields have been dirtied, navigating away from the wizard page will be blocked with a warning/confirmation.
* If the user tries to close their browser tab, a browser-native dialog will appear with a similar warning (no way to have a nice PF warning for that).

Copies the ConfirmModal and RouteGuard components from forklift-ui, which we may want to move to lib-ui.

![Screen Shot 2022-03-22 at 2 49 18 PM](https://user-images.githubusercontent.com/811963/159562412-550b511d-84ce-47f4-ad39-dfa40036aac1.png)

![Screen Shot 2022-03-22 at 3 40 15 PM](https://user-images.githubusercontent.com/811963/159562425-ed8192f4-b899-4a71-b10e-2c52d978ca86.png)

![Screen Shot 2022-03-22 at 3 40 23 PM](https://user-images.githubusercontent.com/811963/159562435-3219aab9-0ec6-44c1-b9eb-ebd984db941d.png)

