### PR TITLE
Fix overly aggressive cache: use current source cluster secret as part of the identifier for the namespace query

### DIFF
--- a/src/api/queries/sourceResources.ts
+++ b/src/api/queries/sourceResources.ts
@@ -27,7 +27,7 @@ export const useValidateSourceNamespaceQuery = (
   isEnabled = true,
 ) => {
   const client = useProxyK8sClient(sourceApiSecret);
-  return useQuery(['namespace', namespace], {
+  return useQuery(['namespace', namespace, sourceApiSecret?.metadata.name], {
     queryFn: () => client?.get(namespaceResource, namespace),
     enabled: !!sourceApiSecret && !!namespace && isEnabled,
     retry: false,


### PR DESCRIPTION
Resolves #48