### PR TITLE
Workaround: make direct CORS requests to crane-reverse-proxy's route instead of using ConsolePlugin proxy

### DIFF
--- a/src/api/proxyHelpers.ts
+++ b/src/api/proxyHelpers.ts
@@ -9,7 +9,7 @@ import {
 import { OAuthSecret } from './types/Secret';
 import { useSourceApiRootQuery } from './queries/sourceResources';
 import { secretMatchesCredentials } from './queries/secrets';
-import { PROXY_SERVICE_URL } from 'src/common/constants';
+// import { PROXY_SERVICE_URL } from 'src/common/constants';
 
 export interface IProxyK8sResponse<T = unknown> {
   data: T;
@@ -41,14 +41,20 @@ export interface IProxyK8sStatus extends K8sResourceCommon {
   };
 }
 
-export const getSourceClusterApiUrl = (clusterSecret: OAuthSecret | null) =>
-  `${PROXY_SERVICE_URL}/${clusterSecret?.metadata.namespace}/${clusterSecret?.metadata.name}`;
+export const getSourceClusterApiUrl = (
+  clusterSecret: OAuthSecret | null,
+  temporaryProxyServiceCORSUrl: string, // TODO restore use of PROXY_SERVICE_URL instead of this arg
+) =>
+  `${temporaryProxyServiceCORSUrl}/${clusterSecret?.metadata.namespace}/${clusterSecret?.metadata.name}`;
 
-export const getSourceClusterK8sClient = (clusterSecret: OAuthSecret | null) => {
+export const getSourceClusterK8sClient = (
+  clusterSecret: OAuthSecret | null,
+  temporaryProxyServiceCORSUrl: string,
+) => {
   if (!clusterSecret) return null;
   const client = ClientFactory.cluster(
     { access_token: clusterSecret ? atob(clusterSecret.data.token) : '', expiry_time: 0 },
-    getSourceClusterApiUrl(clusterSecret),
+    getSourceClusterApiUrl(clusterSecret, temporaryProxyServiceCORSUrl),
   );
   // TODO we could just return `client` if we added generics support to kube-client in lib-ui
   return {

--- a/src/api/queries/corsWorkaround.ts
+++ b/src/api/queries/corsWorkaround.ts
@@ -1,0 +1,34 @@
+import {
+  k8sGet,
+  K8sGroupVersionKind,
+  K8sResourceCommon,
+  useK8sModel,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { useQuery } from 'react-query';
+
+const routeGVK: K8sGroupVersionKind = { group: 'route.openshift.io', version: 'v1', kind: 'Route' };
+type Route = K8sResourceCommon & { spec: { host: string } };
+
+export const useTemporaryCORSProxyUrlQuery = () => {
+  const [routeModel] = useK8sModel(routeGVK);
+  return useQuery('temp-cors-proxy-url', async () => {
+    const route = await k8sGet<Route>({
+      model: routeModel,
+      name: 'proxy',
+      ns: 'openshift-migration',
+    });
+
+    console.log({ route });
+
+    const url = `https://${route.spec.host}`;
+    try {
+      // TODO identify if it's a cert error, pop the modal
+      const testResponse = await fetch(url);
+      console.log({ testResponse });
+    } catch (e) {
+      console.log({ e });
+    }
+
+    return url;
+  });
+};

--- a/src/api/queries/sourceResources.ts
+++ b/src/api/queries/sourceResources.ts
@@ -11,13 +11,13 @@ import { OAuthSecret } from '../types/Secret';
 import { Pod } from '../types/Pod';
 import { PersistentVolumeClaim } from '../types/PersistentVolume';
 import { Service } from '../types/Service';
-import { useTemporaryCORSProxyUrlQuery } from './corsWorkaround';
+import { useTemporaryCORSProxyUrlQuery } from './temporaryCorsWorkaround';
 
 // TODO at top level, mount useTemporaryCORSProxyUrlQuery and handle errors by displaying a modal to ask user to navigate to accept the cert (what URL?)
 // or do the errors come from this source api root query???
 
 export const useSourceApiRootQuery = (sourceApiSecret: OAuthSecret | null, isEnabled = true) => {
-  const temporaryProxyServiceCORSUrl = useTemporaryCORSProxyUrlQuery().data || '';
+  const temporaryProxyServiceCORSUrl = useTemporaryCORSProxyUrlQuery().data?.url || '';
   const apiRootUrl = `${getSourceClusterApiUrl(sourceApiSecret, temporaryProxyServiceCORSUrl)}/api`;
   return useQuery<ApiRootQueryResponse>(['api-root', sourceApiSecret?.metadata.name], {
     queryFn: async () =>
@@ -35,7 +35,7 @@ export const useValidateSourceNamespaceQuery = (
   namespace: string,
   isEnabled = true,
 ) => {
-  const temporaryProxyServiceCORSUrl = useTemporaryCORSProxyUrlQuery().data || '';
+  const temporaryProxyServiceCORSUrl = useTemporaryCORSProxyUrlQuery().data?.url || '';
   const client = getSourceClusterK8sClient(sourceApiSecret, temporaryProxyServiceCORSUrl);
   return useQuery(['namespace', namespace, sourceApiSecret?.metadata.name], {
     queryFn: () => client?.get(namespaceResource, namespace),
@@ -53,7 +53,7 @@ const useSourceNamespacedListQuery = <T extends K8sResourceCommon>(
   { sourceApiSecret, sourceNamespace }: UseSourceNamespacedQueryArgs,
   kindPlural: string,
 ) => {
-  const temporaryProxyServiceCORSUrl = useTemporaryCORSProxyUrlQuery().data || '';
+  const temporaryProxyServiceCORSUrl = useTemporaryCORSProxyUrlQuery().data?.url || '';
   const client = getSourceClusterK8sClient(sourceApiSecret, temporaryProxyServiceCORSUrl);
   const resource = new CoreNamespacedResource(kindPlural, sourceNamespace);
   return useQuery([kindPlural, sourceApiSecret?.metadata.name, sourceNamespace], {

--- a/src/api/queries/temporaryCorsWorkaround.ts
+++ b/src/api/queries/temporaryCorsWorkaround.ts
@@ -11,24 +11,19 @@ type Route = K8sResourceCommon & { spec: { host: string } };
 
 export const useTemporaryCORSProxyUrlQuery = () => {
   const [routeModel] = useK8sModel(routeGVK);
-  return useQuery('temp-cors-proxy-url', async () => {
+  return useQuery<{ url: string; hasCertError: boolean }>('temp-cors-proxy-url', async () => {
     const route = await k8sGet<Route>({
       model: routeModel,
       name: 'proxy',
       ns: 'openshift-migration',
     });
 
-    console.log({ route });
-
     const url = `https://${route.spec.host}`;
     try {
-      // TODO identify if it's a cert error, pop the modal
-      const testResponse = await fetch(url);
-      console.log({ testResponse });
+      await fetch(url);
     } catch (e) {
-      console.log({ e });
+      return { url, hasCertError: true };
     }
-
-    return url;
+    return { url, hasCertError: false };
   });
 };

--- a/src/components/ImportWizard/ImportWizard.tsx
+++ b/src/components/ImportWizard/ImportWizard.tsx
@@ -32,7 +32,7 @@ import './ImportWizard.css';
 import { getYamlFieldKeys } from './helpers';
 import { ConfirmModal } from 'src/common/components/ConfirmModal';
 import { RouteGuard } from 'src/common/components/RouteGuard';
-import { useTemporaryCORSProxyUrlQuery } from 'src/api/queries/corsWorkaround';
+import { TemporaryCertErrorModal } from './TemporaryCertErrorModal';
 
 enum StepId {
   SourceClusterProject = 0,
@@ -44,8 +44,6 @@ enum StepId {
 }
 
 export const ImportWizard: React.FunctionComponent = () => {
-  useTemporaryCORSProxyUrlQuery();
-
   const history = useHistory();
 
   const forms = useImportWizardFormState();
@@ -156,6 +154,7 @@ export const ImportWizard: React.FunctionComponent = () => {
 
   return (
     <ImportWizardFormContext.Provider value={forms}>
+      <TemporaryCertErrorModal />
       <RouteGuard
         when={forms.isSomeFormDirty && createTektonResourcesMutation.status === 'idle'}
         title="Leave this page?"

--- a/src/components/ImportWizard/ImportWizard.tsx
+++ b/src/components/ImportWizard/ImportWizard.tsx
@@ -32,6 +32,7 @@ import './ImportWizard.css';
 import { getYamlFieldKeys } from './helpers';
 import { ConfirmModal } from 'src/common/components/ConfirmModal';
 import { RouteGuard } from 'src/common/components/RouteGuard';
+import { useTemporaryCORSProxyUrlQuery } from 'src/api/queries/corsWorkaround';
 
 enum StepId {
   SourceClusterProject = 0,
@@ -43,6 +44,8 @@ enum StepId {
 }
 
 export const ImportWizard: React.FunctionComponent = () => {
+  useTemporaryCORSProxyUrlQuery();
+
   const history = useHistory();
 
   const forms = useImportWizardFormState();

--- a/src/components/ImportWizard/TemporaryCertErrorModal.tsx
+++ b/src/components/ImportWizard/TemporaryCertErrorModal.tsx
@@ -1,0 +1,42 @@
+import { Modal, TextContent, Text, List, ListItem } from '@patternfly/react-core';
+import * as React from 'react';
+import { useTemporaryCORSProxyUrlQuery } from 'src/api/queries/temporaryCorsWorkaround';
+
+export const TemporaryCertErrorModal: React.FunctionComponent = () => {
+  const corsProxyQuery = useTemporaryCORSProxyUrlQuery();
+  const url = corsProxyQuery.data?.url || '';
+  const hasCertErrors = corsProxyQuery.data?.hasCertError || false;
+  return (
+    <Modal
+      title="Certificate trust required"
+      titleIconVariant="warning"
+      isOpen={hasCertErrors}
+      showClose={false}
+      variant="large"
+    >
+      <TextContent>
+        <Text component="h3">Hello QE tester!</Text>
+        <Text component="p">
+          Due to an OpenShift bug we are currently working around, this UI needs to make CORS
+          requests to a service with an untrusted certificate. This will not be necessary in future
+          builds.
+        </Text>
+        <Text component="p">To proceed:</Text>
+        <List>
+          <ListItem>
+            Open this URL:{' '}
+            <a href={url} target="_blank" rel="noreferrer">
+              {url}
+            </a>
+          </ListItem>
+          <ListItem>
+            Dismiss the security warning by clicking &quot;Advanced&quot;, then &quot;Proceed to
+            ...&quot; (Chrome) or &quot;Accept the risk and continue&quot; (Firefox). It is expected
+            for this to result in a &quot;404 not found&quot; page.
+          </ListItem>
+          <ListItem>Return to this tab and reload the page.</ListItem>
+        </List>
+      </TextContent>
+    </Modal>
+  );
+};


### PR DESCRIPTION
Part of https://github.com/konveyor/crane-ui-plugin/issues/45. To resolve that issue:
* We should wait until there is a 4.10.z build of OpenShift available containing https://github.com/openshift/console/pull/11108
* We should revert this PR, https://github.com/konveyor/crane-reverse-proxy/pull/7 and https://github.com/konveyor/crane-reverse-proxy/pull/9

Adds a `useTemporaryCORSProxyUrlQuery` hook and a `TemporaryCertErrorModal` component. The new query looks up the `proxy` route in `openshift-migration` and attempts to make a request at that URL. If it succeeds, that URL is used for all requests to the source cluster instead of the existing `PROXY_SERVICE_URL`. If that fetch throws a JS error, we know the user needs to accept the untrusted certificate by navigating to that URL, so we open this modal:

<img width="1147" alt="Screen Shot 2022-03-29 at 7 32 46 PM" src="https://user-images.githubusercontent.com/811963/160724414-6167aa49-3e2d-4ad8-b38f-70a533790fa6.png">

The modal cannot be closed without reloading the page as instructed. If the security warning is properly dismissed, it will not reappear.