### PR TITLE
WIP: show namespace switcher bar at the top of the wizard page

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -8,6 +8,14 @@
     }
   },
   {
+    "type": "console.page/route",
+    "properties": {
+      "exact": true,
+      "path": "/k8s/all-namespaces/import-application",
+      "component": { "$codeRef": "ImportPageAllNamespaces" }
+    }
+  },
+  {
     "type": "dev-console.add/action-group",
     "properties": {
       "id": "import-application-group",

--- a/console-extensions.json
+++ b/console-extensions.json
@@ -3,7 +3,7 @@
     "type": "console.page/route",
     "properties": {
       "exact": true,
-      "path": "/import-application/ns/:namespace",
+      "path": "/k8s/ns/:namespace/import-application",
       "component": { "$codeRef": "ImportPage" }
     }
   },
@@ -22,7 +22,7 @@
       "groupId": "import-application-group",
       "label": "Import from cluster",
       "description": "Import a manually deployed application on another cluster to an automated GitOps workflow.",
-      "href": "/import-application/ns/:namespace",
+      "href": "/k8s/ns/:namespace/import-application",
       "icon": { "$codeRef": "icons.importIconElement" }
     }
   },

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "description": "Provides a UI for constructing container migration pipelines within the OpenShift console",
     "exposedModules": {
       "ImportPage": "./components/ImportPage",
+      "ImportPageAllNamespaces": "./components/ImportPageAllNamespaces",
       "icons": "./utils/icons.tsx",
       "actions": "./utils/actions.ts"
     },

--- a/src/components/ImportPageAllNamespaces.tsx
+++ b/src/components/ImportPageAllNamespaces.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import { Redirect } from 'react-router-dom';
+
+const ImportPageAllNamespaces: React.FunctionComponent = () => (
+  <Redirect to="/add/all-namespaces" />
+);
+
+export default ImportPageAllNamespaces;


### PR DESCRIPTION
By changing the URL prefix to `/k8s/ns/:namespace/*` the console automatically shows this project switcher at the top of the page:

![Screen Shot 2022-04-01 at 2 08 49 PM](https://user-images.githubusercontent.com/811963/161318810-66093b91-aef7-4fe0-b75e-a365a9efe997.png)

this helps make sure the user is migrating to the namespace they expect and allows them to switch it easily without going back to the Add page.

WIP: works correctly when switching to another specific namespace, but gives a 404 page when choosing "All projects". Need to figure out how to make that present a project selector like the base Add page does.