### PR TITLE
Generate and reuse a unique OAuthClient for each dev environment

### DIFF
--- a/dev/dev-oauth-client.yaml
+++ b/dev/dev-oauth-client.yaml
@@ -3,6 +3,9 @@ kind: Template
 metadata:
   name: crane-ui-plugin-dev-oauth-client
 parameters:
+  - name: NAME_SUFFIX
+    generate: expression
+    from: '[a-z]{20}'
   - name: OAUTH_SECRET
     generate: expression
     from: '[a-zA-Z0-9]{40}'
@@ -13,7 +16,7 @@ objects:
   - apiVersion: oauth.openshift.io/v1
     kind: OAuthClient
     metadata:
-      name: crane-ui-plugin-dev-oauth-client
+      name: crane-ui-plugin-dev-oauth-client-${NAME_SUFFIX}
     grantMethod: auto
     secret: ${OAUTH_SECRET}
     redirectURIs:


### PR DESCRIPTION
With the current implementation of `dev/start-console.sh`, the OAuthClient `crane-ui-plugin-dev-oauth-client` is recreated on each run of the script with a new secret. This means if one developer starts the console with this script while another developer has already started it on their end, the first developer's authentication requests will start to fail.

This change generates an OAuthClient with a unique name for each developer, storing that name under `./dev/tmp/console-client-name`. Also, if that file exists when the script runs, the existing client will be reused instead of creating a new one. This way, each developer gets their own authentication flow without having to share secrets or worry about clobbering each other.

This change also checks for an existing `./dev/tmp/ca.crt` file and reuses it if present instead of fetching the service-account-token's CA certificate every time the script runs, allowing the use of a different certificate by manually creating that file if necessary.