### PR TITLE
Add authorize flags to ConsolePlugin proxy services

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -113,12 +113,14 @@ spec:
   proxy:
     - type: Service
       alias: remote-cluster
+      authorize: false
       service:
         name: proxy
         namespace: openshift-migration
         port: 8443
     - type: Service
       alias: secret-service
+      authorize: true
       service:
         name: secret-service
         namespace: openshift-migration

--- a/template.yaml
+++ b/template.yaml
@@ -145,12 +145,14 @@ objects:
       proxy:
         - type: Service
           alias: remote-cluster
+          authorize: false
           service:
             name: proxy
             namespace: openshift-migration
             port: 8443
         - type: Service
           alias: secret-service
+          authorize: true
           service:
             name: secret-service
             namespace: openshift-migration


### PR DESCRIPTION
After all the fuss about this `authorize` flag on the ConsolePlugin proxy config, of course I forgot to actually add it. Because of https://bugzilla.redhat.com/show_bug.cgi?id=2058424 and the CORS workaround https://github.com/konveyor/crane-ui-plugin/pull/61, the behavior without these flags is actually correct (only secret-service is actually being used via ConsolePlugin proxy and we do want that one to use `authorize: true`, so the bug forcing `authorize` to `true` is fine) which is why we were able to demo things just fine without them.

When the bug fix is released and the CORS workaround is reverted, we'd suddenly start seeing secret-service fail as the auth token wouldn't be attached to those requests without this flag. This PR proactively fixes that.