### PR TITLE
Add flag for SINGLE_PIPELINE_MODE for tech preview

### DIFF
--- a/src/api/pipelineHelpers.ts
+++ b/src/api/pipelineHelpers.ts
@@ -3,6 +3,7 @@ import { ImportWizardFormState } from 'src/components/ImportWizard/ImportWizardF
 import { getAllPipelineTasks } from './pipelineTaskHelpers';
 import { PipelineKind, PipelineRunKind } from '../reused/pipelines-plugin/src/types';
 import { OAuthSecret } from './types/Secret';
+import { SINGLE_PIPELINE_MODE } from 'src/common/constants';
 
 export interface WizardTektonResources {
   stagePipeline: PipelineKind | null;
@@ -140,6 +141,9 @@ export const formsToTektonResources = (
     },
   };
 
+  if (SINGLE_PIPELINE_MODE) {
+    return { stagePipeline: null, stagePipelineRun: null, cutoverPipeline, cutoverPipelineRun };
+  }
   return { stagePipeline, stagePipelineRun, cutoverPipeline, cutoverPipelineRun };
 };
 
@@ -152,16 +156,18 @@ export const yamlToTektonResources = (
   let stagePipelineRun: PipelineRunKind | null | undefined;
   let cutoverPipeline: PipelineKind | undefined;
   let cutoverPipelineRun: PipelineRunKind | undefined;
-  try {
-    stagePipeline = stagePipelineYaml ? (yaml.load(stagePipelineYaml) as PipelineKind) : null;
-    // eslint-disable-next-line no-empty
-  } catch (e) {}
-  try {
-    stagePipelineRun = stagePipelineRunYaml
-      ? (yaml.load(stagePipelineRunYaml) as PipelineRunKind)
-      : null;
-    // eslint-disable-next-line no-empty
-  } catch (e) {}
+  if (!SINGLE_PIPELINE_MODE) {
+    try {
+      stagePipeline = stagePipelineYaml ? (yaml.load(stagePipelineYaml) as PipelineKind) : null;
+      // eslint-disable-next-line no-empty
+    } catch (e) {}
+    try {
+      stagePipelineRun = stagePipelineRunYaml
+        ? (yaml.load(stagePipelineRunYaml) as PipelineRunKind)
+        : null;
+      // eslint-disable-next-line no-empty
+    } catch (e) {}
+  }
   try {
     cutoverPipeline = yaml.load(cutoverPipelineYaml) as PipelineKind;
     // eslint-disable-next-line no-empty

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,2 +1,4 @@
 export const PROXY_SERVICE_URL = '/api/proxy/plugin/crane-ui-plugin/remote-cluster';
 export const SECRET_SERVICE_URL = '/api/proxy/plugin/crane-ui-plugin/secret-service';
+
+export const SINGLE_PIPELINE_MODE = true; // Disable/remove this after tech preview


### PR DESCRIPTION
Adds a constant `SINGLE_PIPELINE_MODE` set to true. With this constant set to true, stage pipelines will never be visualized or created and cutover pipelines will not be given the `-cutover` suffix. I've kept changes to a minimum so this can be easily reverted later (e.g. stage pipeline variables still get declared/initialized by the helper functions, just never returned).

If we want to develop additional features for post-tech-preview, we can set this flag to false to re-enable the prior behavior as long as we set it back to true before the tech preview release.