### PR TITLE
package.json scripts: explicitly run commands from $(yarn bin) so no environment tries to resolve them globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "build-dev": "yarn clean && yarn ts-node node_modules/.bin/webpack",
     "start": "yarn ts-node node_modules/.bin/webpack serve",
     "start-console": "./dev/start-console.sh",
-    "i18n": "i18next \"src/**/*.{js,jsx,ts,tsx}\" [-oc] -c i18next-parser.config.js",
-    "ts-node": "ts-node -O '{\"module\":\"commonjs\"}'",
-    "tsc": "tsc --noEmit",
-    "lint": "eslint ./src",
+    "i18n": "$(yarn bin)/i18next \"src/**/*.{js,jsx,ts,tsx}\" [-oc] -c i18next-parser.config.js",
+    "ts-node": "$(yarn bin)/ts-node -O '{\"module\":\"commonjs\"}'",
+    "tsc": "$(yarn bin)/tsc --noEmit",
+    "lint": "$(yarn bin)/eslint ./src",
     "lint:fix": "yarn lint --fix"
   },
   "devDependencies": {


### PR DESCRIPTION
OpenShift CI is running into a strange issue when running eslint from our package.json scripts, where it is trying to resolve a global eslint rather than the one from `node_modules/.bin`. This change prefixes all commands that should be run from `node_modules` with `$(yarn bin)/` (which resolves to `node_modules/.bin/` by default) so yarn never tries to run the global versions.