### PR TITLE
Console imports page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 dev/tmp/
+.DS_Store

--- a/console-extensions.json
+++ b/console-extensions.json
@@ -8,6 +8,14 @@
     }
   },
   {
+    "type": "console.page/route",
+    "properties": {
+      "exact": true,
+      "path": "/application-imports/ns/:namespace",
+      "component": { "$codeRef": "AppImportsPage" }
+    }
+  },
+  {
     "type": "dev-console.add/action-group",
     "properties": {
       "id": "import-application-group",
@@ -24,6 +32,17 @@
       "description": "Import a manually deployed application on another cluster to an automated GitOps workflow.",
       "href": "/import-application/ns/:namespace",
       "icon": { "$codeRef": "icons.importIconElement" }
+    }
+  },
+  {
+    "type": "dev-console.add/action",
+    "properties": {
+      "id": "application-imports",
+      "groupId": "import-application-group",
+      "label": "Application imports",
+      "description": "View imported applications.",
+      "href": "/application-imports/ns/:namespace",
+      "icon": { "$codeRef": "icons.applicationsIconElement" }
     }
   },
   {

--- a/dev/start-console.sh
+++ b/dev/start-console.sh
@@ -7,7 +7,7 @@ if [ $? -eq 1 ]; then
     echo "You must be logged into a cluster via oc as a cluster admin."
     PREREQS_MET=0
 fi
-which python > /dev/null 2>&1
+which python3 > /dev/null 2>&1
 if [ $? -eq 1 ]; then
     echo "You must have python installed and on your path to run this script."
     PREREQS_MET=0
@@ -16,7 +16,7 @@ which jq > /dev/null 2>&1
 if [ $? -eq 1 ]; then
     echo "You must have jq installed and on your path to run this script."
     PREREQS_MET=0
-fi 
+fi
 if [ ! -f "./dev/dev-oauth-client.yaml" ]; then
     echo "You must run this script from the root of your crane-ui-plugin directory."
     PREREQS_MET=0

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "description": "Provides a UI for constructing container migration pipelines within the OpenShift console",
     "exposedModules": {
       "ImportPage": "./components/ImportPage",
+      "AppImportsPage": "./components/AppImportsPage",
       "icons": "./utils/icons.tsx",
       "actions": "./utils/actions.ts"
     },

--- a/src/api/pipelineHelpers.ts
+++ b/src/api/pipelineHelpers.ts
@@ -11,6 +11,23 @@ export interface WizardTektonResources {
   cutoverPipelineRun: PipelineRunKind;
 }
 
+const workspaceVolumeClaimTemplate = {
+  spec: { accessModes: ['ReadWriteOnce'], resources: { requests: { storage: '10Mi' } } },
+};
+
+const pipelineCommon: PipelineKind = {
+  apiVersion: 'tekton.dev/v1beta1',
+  kind: 'Pipeline',
+  spec: {
+    params: [
+      { name: 'source-cluster-secret', type: 'string' },
+      { name: 'source-namespace', type: 'string' },
+      { name: 'destination-cluster-secret', type: 'string' },
+    ],
+    tasks: [],
+  },
+};
+
 export const formsToTektonResources = (
   forms: ImportWizardFormState,
   destinationApiSecret: OAuthSecret,
@@ -20,19 +37,6 @@ export const formsToTektonResources = (
   const { pipelineName } = forms.pipelineSettings.values;
   const { selectedPVCs } = forms.pvcSelect.values;
   const isStatefulMigration = selectedPVCs.length > 0;
-
-  const pipelineCommon: PipelineKind = {
-    apiVersion: 'tekton.dev/v1beta1',
-    kind: 'Pipeline',
-    spec: {
-      params: [
-        { name: 'source-cluster-secret', type: 'string' },
-        { name: 'source-namespace', type: 'string' },
-        { name: 'destination-cluster-secret', type: 'string' },
-      ],
-      tasks: [],
-    },
-  };
 
   const pipelineRunCommon: PipelineRunKind = {
     apiVersion: 'tekton.dev/v1beta1',
@@ -45,10 +49,6 @@ export const formsToTektonResources = (
         { name: 'source-namespace', value: sourceNamespace },
       ],
     },
-  };
-
-  const workspaceVolumeClaimTemplate = {
-    spec: { accessModes: ['ReadWriteOnce'], resources: { requests: { storage: '10Mi' } } },
   };
 
   const tasks = getAllPipelineTasks(forms, namespace);

--- a/src/api/queries/pipelines.ts
+++ b/src/api/queries/pipelines.ts
@@ -50,51 +50,37 @@ export const useWatchPipelineRuns = () => {
 };
 
 interface CopyPVCDataParams {
-  hasPendingRun: boolean;
-  secrets: (OAuthSecret | null)[];
+  stagePipelineRun: PipelineRunKind;
+  stagePipeline: PipelineKind;
 }
 export const useCopyPVCDataMutation = (onSuccess: () => void) => {
-  // const [pipelineModel] = useK8sModel(pipelineGVK);
-  // const [pipelineRunModel] = useK8sModel(pipelineRunGVK);
+  const [pipelineRunModel] = useK8sModel(pipelineRunGVK);
 
-  const [secretModel] = useK8sModel(secretGVK);
-  return useMutation<any, Error, CopyPVCDataParams>(
-    async ({ secrets, hasPendingRun }) => {
-      // const cutoverPipeline = await k8sCreate({
-      //   model: pipelineModel,
-      //   data: resources.cutoverPipeline,
-      // });
-      // const cutoverPipelineRef = getObjectRef(cutoverPipeline);
+  // const [secretModel] = useK8sModel(secretGVK);
+  return useMutation<unknown, Error, CopyPVCDataParams>(
+    async ({ stagePipelineRun }) => {
+      console.log(stagePipelineRun.spec.status);
 
-      // const createOwnedResource = <T extends K8sResourceCommon>(model: K8sModel, data: T) =>
-      //   k8sCreate({ model, data: attachOwnerReference(data, cutoverPipelineRef) });
-
-      // const [cutoverPipelineRun, stagePipeline, stagePipelineRun] = await Promise.all([
-      //   createOwnedResource(pipelineRunModel, resources.cutoverPipelineRun),
-      //   resources.stagePipeline
-      //     ? createOwnedResource(pipelineModel, resources.stagePipeline)
-      //     : Promise.resolve(null),
-      //   resources.stagePipelineRun
-      //     ? createOwnedResource(pipelineRunModel, resources.stagePipelineRun)
-      //     : Promise.resolve(null),
-      // ]);
-
-      await Promise.all(
-        secrets.map((secret) => {
-          if (!secret) return Promise.resolve();
-          return k8sPatch({
-            model: secretModel,
-            resource: secret,
-            data: [{ op: 'remove', path: '/spec/status' }],
-            // data: [
-            //   !secret.metadata.ownerReferences
-            //     ? { op: 'add', path: '/metadata/ownerReferences', value: [cutoverPipelineRef] }
-            //     : { op: 'add', path: '/metadata/ownerReferences/-', value: cutoverPipelineRef },
-            // ],
-          });
-        }),
-      );
-      // return { stagePipeline, stagePipelineRun, cutoverPipeline, cutoverPipelineRun };
+      if (stagePipelineRun.spec.status === 'PipelineRunPending') {
+        return k8sPatch({
+          model: pipelineRunModel,
+          resource: stagePipelineRun,
+          data: [{ op: 'remove', path: '/spec/status' }],
+        });
+      } else {
+        // const newPipelineRun = {
+        //   spec: stagePipelineRun.spec,
+        //   metadata: {
+        //     generateName: stagePipeline.metadata.name,
+        //     ownerReferences // same one from the stagePipelinerun.metadata.ornwerReferences
+        //   }
+        // }
+        // return k8sCreate({
+        //   model: pipelineRunModel,
+        //   resource: stagePipelineRun,
+        //   data: ,
+        // })
+      }
     },
     { onSuccess },
   );

--- a/src/components/AppImports/AppImports.tsx
+++ b/src/components/AppImports/AppImports.tsx
@@ -19,12 +19,40 @@ import {
 import { TableComposable, Tbody, Thead, Tr, Th, Td } from '@patternfly/react-table';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import CaretDownIcon from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
-import { useWatchPipelines } from 'src/api/queries/pipelines';
+import { PipelineKind, PipelineRunKind } from 'src/reused/pipelines-plugin/src/types';
+// import { secretGVK } from 'src/api/queries/secrets';
+// import { useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
+// import { useCopyPVCDataMutation } from 'src/api/queries/pipelines';
+// import { useNamespaceContext } from 'src/context/NamespaceContext';
+// import { } from 'src/api/pipelineHelpers';
 
-export const AppImports: React.FunctionComponent = () => {
-  const [activeTabKey, setActiveTabKey] = React.useState<string | number>(0);
+interface IAppImportsProps {
+  pipelines: {
+    data: PipelineKind[];
+    loaded: boolean;
+    error: any;
+  };
+  pipelineRuns: {
+    data: PipelineRunKind[];
+    loaded: boolean;
+    error: any;
+  };
+}
 
-  const pipelines = useWatchPipelines();
+export const AppImports: React.FunctionComponent<IAppImportsProps> = ({
+  pipelines,
+  pipelineRuns,
+}: IAppImportsProps) => {
+  // const [pipelineRunSecret, setPipelineRunSecret] = React.useState(pipelineRuns?.data[0]?.spec?.params?.find(param => param.name === 'source-cluster-secret')?.name);
+
+  // React.useEffect(() => {
+  //   // not this kinda secret, huh?
+  //   setPipelineRunSecret(pipelineRuns?.data[0]?.spec?.params?.find(param => param.name === 'source-cluster-secret')?.name);
+  // }, [pipelineRuns]);
+
+  // const namespace = useNamespaceContext();
+
+  const [activeTabKey, setActiveTabKey] = React.useState<string | number>('rocket-chat-cutover');
 
   const handleTabClick = (
     event: React.MouseEvent<HTMLElement, MouseEvent>,
@@ -88,85 +116,114 @@ export const AppImports: React.FunctionComponent = () => {
     </DropdownItem>,
   ];
 
+  // const [secretModel] = useK8sModel(secretGVK);
+
+  // const copyPvcData = useCopyPVCDataMutation(() => {
+  //   console.log('started cutover!');
+  // });
+
   return (
     <>
       <PageSection variant="light" type="tabs" className={spacing.pMd}>
         <Tabs activeKey={activeTabKey} onSelect={handleTabClick} isBox>
-          <Tab eventKey={0} title={<TabTitleText>application-0</TabTitleText>}>
-            <Grid hasGutter className={spacing.ptMd}>
-              <GridItem span={6}>
-                <Title headingLevel="h3">application-0</Title>
-              </GridItem>
+          {pipelines.data &&
+            pipelines.data
+              .filter((pipeline) => pipeline.metadata?.name?.includes('-cutover'))
+              .map((pipeline) => {
+                console.log('first ', pipeline);
+                return (
+                  pipeline.metadata?.name && (
+                    <Tab
+                      eventKey={pipeline.metadata.name}
+                      title={<TabTitleText>{pipeline.metadata.name}</TabTitleText>}
+                    >
+                      <Grid hasGutter className={spacing.ptMd}>
+                        <GridItem span={6}>
+                          <Title headingLevel="h3">{pipeline.metadata.name}</Title>
+                        </GridItem>
 
-              <GridItem span={6}>
-                <Button
-                  onClick={() => alert('todo copy pvc data')}
-                  variant="secondary"
-                  className="pf-u-mr-sm"
-                >
-                  Copy PVC data
-                </Button>
-                <Button onClick={() => alert('todo start cutover')} variant="secondary">
-                  Cutover
-                </Button>
-                <Dropdown
-                  onSelect={onAppKebabSelect}
-                  toggle={<KebabToggle onToggle={toggleAppKebabOpen} id="toggle-id-app-kebab" />}
-                  isOpen={isAppKebabOpen}
-                  isPlain
-                  dropdownItems={appDropdownItems}
-                />
-              </GridItem>
+                        <GridItem span={6}>
+                          <Button
+                            onClick={() => {
+                              // const hasPendingRun = pipelineRuns.data.some(run => run.spec.status === 'PipelineRunPending');
+                              // copyPvcData.mutate({hasPendingRun, secrets: [pipelineRunSecret]});
+                            }}
+                            variant="secondary"
+                            className="pf-u-mr-sm"
+                          >
+                            Copy PVC data
+                          </Button>
+                          <Button
+                            onClick={() =>
+                              alert(`todo start cutover for ${pipeline.metadata?.name}`)
+                            }
+                            variant="secondary"
+                          >
+                            Cutover
+                          </Button>
+                          <Dropdown
+                            onSelect={onAppKebabSelect}
+                            toggle={
+                              <KebabToggle onToggle={toggleAppKebabOpen} id="toggle-id-app-kebab" />
+                            }
+                            isOpen={isAppKebabOpen}
+                            isPlain
+                            dropdownItems={appDropdownItems}
+                          />
+                        </GridItem>
 
-              <GridItem>
-                <TableComposable
-                  aria-label="Application import review"
-                  variant="compact"
-                  borders={false}
-                  gridBreakPoint="grid"
-                >
-                  <Thead>
-                    <Th modifier="nowrap" id="source-project-heading">
-                      Source project
-                    </Th>
-                    <Th modifier="nowrap" id="pvc-heading">
-                      Persistant volume claims
-                    </Th>
-                    <Th modifier="nowrap" id="status-heading">
-                      Status
-                    </Th>
-                  </Thead>
-                  <Tbody>
-                    <Tr>
-                      <Td
-                        className="pf-m-truncate"
-                        dataLabel="Source project"
-                        aria-labelledby="source-project-heading"
-                      >
-                        my-project
-                      </Td>
-                      <Td
-                        className="pf-m-truncate"
-                        dataLabel="Persistant volume claims"
-                        aria-labelledby="pvc-heading"
-                      >
-                        1
-                      </Td>
-                      <Td
-                        className="pf-m-truncate"
-                        dataLabel="Status"
-                        aria-labelledby="status-heading"
-                      >
-                        Ready
-                      </Td>
-                    </Tr>
-                  </Tbody>
-                </TableComposable>
-              </GridItem>
-            </Grid>
-          </Tab>
+                        <GridItem>
+                          <TableComposable
+                            aria-label="Pipeline import review"
+                            variant="compact"
+                            borders={false}
+                            gridBreakPoint="grid"
+                          >
+                            <Thead>
+                              <Th modifier="nowrap" id="source-project-heading">
+                                Source project
+                              </Th>
+                              <Th modifier="nowrap" id="pvc-heading">
+                                Persistant volume claims
+                              </Th>
+                              <Th modifier="nowrap" id="status-heading">
+                                Status
+                              </Th>
+                            </Thead>
+                            <Tbody>
+                              <Tr>
+                                <Td
+                                  className="pf-m-truncate"
+                                  dataLabel="Source project"
+                                  aria-labelledby="source-project-heading"
+                                >
+                                  my-project
+                                </Td>
+                                <Td
+                                  className="pf-m-truncate"
+                                  dataLabel="Persistant volume claims"
+                                  aria-labelledby="pvc-heading"
+                                >
+                                  1
+                                </Td>
+                                <Td
+                                  className="pf-m-truncate"
+                                  dataLabel="Status"
+                                  aria-labelledby="status-heading"
+                                >
+                                  Ready
+                                </Td>
+                              </Tr>
+                            </Tbody>
+                          </TableComposable>
+                        </GridItem>
+                      </Grid>
+                    </Tab>
+                  )
+                );
+              })}
 
-          <Tab isDisabled eventKey={1} title={<TabTitleText>application-1</TabTitleText>}>
+          <Tab eventKey={1} title={<TabTitleText>stub-application-1</TabTitleText>}>
             stub
           </Tab>
         </Tabs>
@@ -260,26 +317,27 @@ export const AppImports: React.FunctionComponent = () => {
                 <Th modifier="nowrap" id="delete-heading"></Th>
               </Thead>
               <Tbody>
-                {pipelines &&
-                  pipelines.data &&
-                  pipelines.data
-                    .filter((pipeline) => pipeline.metadata?.name?.includes('-stage')) // or filter -cutover?
-                    .map((el) => {
+                {pipelineRuns.data &&
+                  pipelineRuns.data
+                    .filter((pipeline) => pipeline.metadata?.name?.includes('-stage'))
+                    .map((pipeline) => {
+                      console.log('second ', pipeline);
+                      console.log(pipeline?.metadata?.ownerReferences?.[0].uid);
                       return (
-                        <Tr key={`${el.metadata?.name}`}>
+                        <Tr key={`${pipeline.metadata?.name}`}>
                           <Td
                             className="pf-m-truncate"
                             dataLabel="Pipeline run"
                             aria-labelledby="pipeline-run-heading"
                           >
-                            {el.metadata?.name}
+                            {pipeline.metadata?.name}
                           </Td>
                           <Td
                             className="pf-m-truncate"
                             dataLabel="Executed"
                             aria-labelledby="executed-heading"
                           >
-                            {el.metadata?.creationTimestamp}
+                            {pipeline.metadata?.creationTimestamp}
                           </Td>
                           <Td
                             className="pf-m-truncate"
@@ -296,7 +354,7 @@ export const AppImports: React.FunctionComponent = () => {
                             <Button
                               variant="secondary"
                               onClick={() =>
-                                alert(`todo implement delete for ${el.metadata?.name}`)
+                                alert(`todo implement delete for ${pipeline.metadata?.name}`)
                               }
                             >
                               Delete
@@ -306,6 +364,55 @@ export const AppImports: React.FunctionComponent = () => {
                       );
                     })}
               </Tbody>
+
+              {/* <Tbody>
+                {pipelines.data &&
+                  pipelines.data
+                    .filter((pipeline) => pipeline.metadata?.name?.includes('-stage'))
+                    .map((pipeline) => {
+                      console.log('second ', pipeline);
+                      console.log(pipeline?.metadata?.ownerReferences?.[0].uid);
+                      return (
+                        <Tr key={`${pipeline.metadata?.name}`}>
+                          <Td
+                            className="pf-m-truncate"
+                            dataLabel="Pipeline run"
+                            aria-labelledby="pipeline-run-heading"
+                          >
+                            {pipeline.metadata?.name}
+                          </Td>
+                          <Td
+                            className="pf-m-truncate"
+                            dataLabel="Executed"
+                            aria-labelledby="executed-heading"
+                          >
+                            {pipeline.metadata?.creationTimestamp}
+                          </Td>
+                          <Td
+                            className="pf-m-truncate"
+                            dataLabel="Result"
+                            aria-labelledby="result-heading"
+                          >
+                            todo
+                          </Td>
+                          <Td
+                            className="pf-m-truncate"
+                            dataLabel=""
+                            aria-labelledby="delete-heading"
+                          >
+                            <Button
+                              variant="secondary"
+                              onClick={() =>
+                                alert(`todo implement delete for ${pipeline.metadata?.name}`)
+                              }
+                            >
+                              Delete
+                            </Button>
+                          </Td>
+                        </Tr>
+                      );
+                    })}
+              </Tbody> */}
             </TableComposable>
           </GridItem>
         </Grid>

--- a/src/components/AppImports/AppImports.tsx
+++ b/src/components/AppImports/AppImports.tsx
@@ -30,12 +30,12 @@ interface IAppImportsProps {
   pipelines: {
     data: PipelineKind[];
     loaded: boolean;
-    error: any;
+    error: Error;
   };
   pipelineRuns: {
     data: PipelineRunKind[];
     loaded: boolean;
-    error: any;
+    error: Error;
   };
 }
 
@@ -44,11 +44,6 @@ export const AppImports: React.FunctionComponent<IAppImportsProps> = ({
   pipelineRuns,
 }: IAppImportsProps) => {
   // const [pipelineRunSecret, setPipelineRunSecret] = React.useState(pipelineRuns?.data[0]?.spec?.params?.find(param => param.name === 'source-cluster-secret')?.name);
-
-  // React.useEffect(() => {
-  //   // not this kinda secret, huh?
-  //   setPipelineRunSecret(pipelineRuns?.data[0]?.spec?.params?.find(param => param.name === 'source-cluster-secret')?.name);
-  // }, [pipelineRuns]);
 
   // const namespace = useNamespaceContext();
 
@@ -128,25 +123,27 @@ export const AppImports: React.FunctionComponent<IAppImportsProps> = ({
         <Tabs activeKey={activeTabKey} onSelect={handleTabClick} isBox>
           {pipelines.data &&
             pipelines.data
-              .filter((pipeline) => pipeline.metadata?.name?.includes('-cutover'))
-              .map((pipeline) => {
-                console.log('first ', pipeline);
+              .filter((cutOverPipeline) => cutOverPipeline.metadata?.name?.includes('-cutover'))
+              .map((cutOverPipeline) => {
+                console.log('first ', cutOverPipeline);
                 return (
-                  pipeline.metadata?.name && (
+                  cutOverPipeline.metadata?.name && (
                     <Tab
-                      eventKey={pipeline.metadata.name}
-                      title={<TabTitleText>{pipeline.metadata.name}</TabTitleText>}
+                      eventKey={cutOverPipeline.metadata.name}
+                      title={<TabTitleText>{cutOverPipeline.metadata.name}</TabTitleText>}
                     >
                       <Grid hasGutter className={spacing.ptMd}>
                         <GridItem span={6}>
-                          <Title headingLevel="h3">{pipeline.metadata.name}</Title>
+                          <Title headingLevel="h3">{cutOverPipeline.metadata.name}</Title>
                         </GridItem>
 
                         <GridItem span={6}>
                           <Button
                             onClick={() => {
+                              // stagePipline
+                              // latest stagePipelineRun (filter on ownerReference & "-staged")
                               // const hasPendingRun = pipelineRuns.data.some(run => run.spec.status === 'PipelineRunPending');
-                              // copyPvcData.mutate({hasPendingRun, secrets: [pipelineRunSecret]});
+                              // copyPvcData.mutate({stagePipelineRun, stagePipeline: cutOverPipeline});
                             }}
                             variant="secondary"
                             className="pf-u-mr-sm"
@@ -154,9 +151,9 @@ export const AppImports: React.FunctionComponent<IAppImportsProps> = ({
                             Copy PVC data
                           </Button>
                           <Button
-                            onClick={() =>
-                              alert(`todo start cutover for ${pipeline.metadata?.name}`)
-                            }
+                            onClick={() => {
+                              // alert(`todo start cutover for ${pipeline.metadata?.name}`)
+                            }}
                             variant="secondary"
                           >
                             Cutover

--- a/src/components/AppImports/AppImports.tsx
+++ b/src/components/AppImports/AppImports.tsx
@@ -12,14 +12,18 @@ import {
   KebabToggle,
   DropdownItem,
   Toolbar,
-  // ToolbarItem
+  ToolbarContent,
+  ToolbarItem
 } from '@patternfly/react-core';
 import { TableComposable, Tbody, Thead, Tr, Th, Td } from '@patternfly/react-table';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { useWatchPipelines } from 'src/api/queries/pipelines';
 
 export const AppImports: React.FunctionComponent = () => {
-  // const history = useHistory();
+
   const [activeTabKey, setActiveTabKey] = React.useState<string | number>(0);
+
+  const pipelines = useWatchPipelines();
 
   const handleTabClick = (event: React.MouseEvent<HTMLElement, MouseEvent>, eventKey: string | number) => {
     setActiveTabKey(eventKey);
@@ -57,8 +61,8 @@ export const AppImports: React.FunctionComponent = () => {
               </GridItem>
 
               <GridItem span={6}>
-                <Button>Copy PVC data</Button>
-                <Button>Cutover</Button>
+                <Button variant="secondary" className="pf-u-mr-sm">Copy PVC data</Button>
+                <Button variant="secondary">Cutover</Button>
                 <Dropdown
                   onSelect={onKebabSelect}
                   toggle={<KebabToggle onToggle={toggleKebabOpen} id="toggle-id-0" />}
@@ -89,7 +93,7 @@ export const AppImports: React.FunctionComponent = () => {
 
           </Tab>
 
-          <Tab eventKey={1} title={<TabTitleText>application-1</TabTitleText>}>
+          <Tab isDisabled eventKey={1} title={<TabTitleText>application-1</TabTitleText>}>
             stub
           </Tab>
 
@@ -98,16 +102,52 @@ export const AppImports: React.FunctionComponent = () => {
       </PageSection>
 
       <PageSection variant="light" type="default" className={spacing.pMd}>
-        <Grid>
+        <Grid hasGutter>
           <GridItem>
             <Title headingLevel="h3">"Pipeline" history</Title>
           </GridItem>
+
           <GridItem>
             <Toolbar>
-              {/* toolbar items */}
+              <ToolbarContent>
+                <ToolbarItem>filter 1</ToolbarItem>
+                <ToolbarItem>filter 2</ToolbarItem>
+                <ToolbarItem>button</ToolbarItem>
+                <ToolbarItem>button</ToolbarItem>
+                <ToolbarItem>kebab-dropdown</ToolbarItem>
+              </ToolbarContent>
             </Toolbar>
-            <div>sortable table here</div>
           </GridItem>
+
+          <GridItem>
+            <TableComposable aria-label="Pipeline history" variant="compact" borders={false} gridBreakPoint="grid-md">
+              <Thead>
+                <Th modifier="nowrap" id="pipeline-run-heading">Pipeline run</Th>
+                <Th modifier="nowrap" id="executed-heading">Executed</Th>
+                <Th modifier="nowrap" id="result-heading">Result</Th>
+                <Th modifier="nowrap" id="delete-heading"></Th>
+              </Thead>
+              <Tbody>
+
+                {pipelines && pipelines.data && pipelines.data.map((el) => {
+                  console.log(el);
+                  return (
+                    <Tr>
+                      <Td className="pf-m-truncate" dataLabel="Pipeline run" aria-labelledby="pipeline-run-heading">{el.metadata?.name}</Td>
+                      <Td className="pf-m-truncate" dataLabel="Executed" aria-labelledby="executed-heading">{el.metadata?.creationTimestamp}</Td>
+                      <Td className="pf-m-truncate" dataLabel="Result" aria-labelledby="result-heading">todo</Td>
+                      <Td className="pf-m-truncate" dataLabel="" aria-labelledby="delete-heading">
+                        <Button variant="secondary" onClick={() => alert('todo')}>Delete</Button>
+                      </Td>
+                    </Tr>
+                  )
+                })}
+
+              </Tbody>
+            </TableComposable>
+
+          </GridItem>
+
         </Grid>
       </PageSection>
     </>

--- a/src/components/AppImports/AppImports.tsx
+++ b/src/components/AppImports/AppImports.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  DropdownToggle,
   PageSection,
   Tabs,
   Tab,
@@ -13,141 +14,300 @@ import {
   DropdownItem,
   Toolbar,
   ToolbarContent,
-  ToolbarItem
+  ToolbarItem,
 } from '@patternfly/react-core';
 import { TableComposable, Tbody, Thead, Tr, Th, Td } from '@patternfly/react-table';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import CaretDownIcon from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
 import { useWatchPipelines } from 'src/api/queries/pipelines';
 
 export const AppImports: React.FunctionComponent = () => {
-
   const [activeTabKey, setActiveTabKey] = React.useState<string | number>(0);
 
   const pipelines = useWatchPipelines();
 
-  const handleTabClick = (event: React.MouseEvent<HTMLElement, MouseEvent>, eventKey: string | number) => {
+  const handleTabClick = (
+    event: React.MouseEvent<HTMLElement, MouseEvent>,
+    eventKey: string | number,
+  ) => {
     setActiveTabKey(eventKey);
-  }
+  };
 
-  const onFocus = () => {
-    const element = document.getElementById('toggle-id-0');
+  const onFocus = (id: string) => {
+    const element = document.getElementById(id);
     element?.focus();
   };
 
-  const [isKebabOpen, toggleKebabOpen] = React.useReducer((isOpen) => !isOpen, false);
+  const [isAppKebabOpen, toggleAppKebabOpen] = React.useReducer((isOpen) => !isOpen, false);
+  const [isFilter1KebabOpen, toggleFilter1KebabOpen] = React.useReducer((isOpen) => !isOpen, false);
+  const [isFilter2KebabOpen, toggleFilter2KebabOpen] = React.useReducer((isOpen) => !isOpen, false);
 
-  const onKebabSelect = (event?: React.SyntheticEvent<HTMLDivElement, Event> | undefined) => {
-    toggleKebabOpen();
-    onFocus();
-  }
+  const onAppKebabSelect = () => {
+    toggleAppKebabOpen();
+    onFocus('toggle-id-app-kebab');
+  };
 
-  const dropdownItems = [
-    <DropdownItem key="delete" component="button">Delete</DropdownItem>,
-    <DropdownItem key="view-pipelies" component="button">
+  const onFilter1KebabSelect = () => {
+    toggleFilter1KebabOpen();
+    onFocus('toggle-id-filter1');
+  };
+
+  const onFilter2KebabSelect = () => {
+    toggleFilter2KebabOpen();
+    onFocus('toggle-id-filter2');
+  };
+
+  const appDropdownItems = [
+    <DropdownItem key="app-delete" component="button" onClick={() => alert('todo confirm delete')}>
+      Delete
+    </DropdownItem>,
+    <DropdownItem
+      key="app-view-pipelies"
+      component="button"
+      onClick={() => alert('todo view pipelines')}
+    >
       View pipelines
-    </DropdownItem>
-  ]
+    </DropdownItem>,
+  ];
+
+  const filter1DropdownItems = [
+    <DropdownItem key="filter1-option1" component="button" onClick={() => alert('todo')}>
+      option-1
+    </DropdownItem>,
+    <DropdownItem key="filter1-option2" component="button" onClick={() => alert('todo')}>
+      option-2
+    </DropdownItem>,
+  ];
+
+  const filter2DropdownItems = [
+    <DropdownItem key="filter2-option1" component="button" onClick={() => alert('todo')}>
+      option-1
+    </DropdownItem>,
+    <DropdownItem key="filter2-option2" component="button" onClick={() => alert('todo')}>
+      option-2
+    </DropdownItem>,
+  ];
 
   return (
     <>
       <PageSection variant="light" type="tabs" className={spacing.pMd}>
         <Tabs activeKey={activeTabKey} onSelect={handleTabClick} isBox>
           <Tab eventKey={0} title={<TabTitleText>application-0</TabTitleText>}>
-
             <Grid hasGutter className={spacing.ptMd}>
-
               <GridItem span={6}>
                 <Title headingLevel="h3">application-0</Title>
               </GridItem>
 
               <GridItem span={6}>
-                <Button variant="secondary" className="pf-u-mr-sm">Copy PVC data</Button>
-                <Button variant="secondary">Cutover</Button>
+                <Button
+                  onClick={() => alert('todo copy pvc data')}
+                  variant="secondary"
+                  className="pf-u-mr-sm"
+                >
+                  Copy PVC data
+                </Button>
+                <Button onClick={() => alert('todo start cutover')} variant="secondary">
+                  Cutover
+                </Button>
                 <Dropdown
-                  onSelect={onKebabSelect}
-                  toggle={<KebabToggle onToggle={toggleKebabOpen} id="toggle-id-0" />}
-                  isOpen={isKebabOpen}
+                  onSelect={onAppKebabSelect}
+                  toggle={<KebabToggle onToggle={toggleAppKebabOpen} id="toggle-id-app-kebab" />}
+                  isOpen={isAppKebabOpen}
                   isPlain
-                  dropdownItems={dropdownItems}
+                  dropdownItems={appDropdownItems}
                 />
               </GridItem>
 
               <GridItem>
-                <TableComposable aria-label="Application import review" variant="compact" borders={false} gridBreakPoint="grid">
+                <TableComposable
+                  aria-label="Application import review"
+                  variant="compact"
+                  borders={false}
+                  gridBreakPoint="grid"
+                >
                   <Thead>
-                    <Th modifier="nowrap" id="source-project-heading">Source project</Th>
-                    <Th modifier="nowrap" id="pvc-heading">Persistant volume claims</Th>
-                    <Th modifier="nowrap" id="status-heading">Status</Th>
+                    <Th modifier="nowrap" id="source-project-heading">
+                      Source project
+                    </Th>
+                    <Th modifier="nowrap" id="pvc-heading">
+                      Persistant volume claims
+                    </Th>
+                    <Th modifier="nowrap" id="status-heading">
+                      Status
+                    </Th>
                   </Thead>
                   <Tbody>
                     <Tr>
-                      <Td className="pf-m-truncate" dataLabel="Source project" aria-labelledby="source-project-heading">my-project</Td>
-                      <Td className="pf-m-truncate" dataLabel="Persistant volume claims" aria-labelledby="pvc-heading">1</Td>
-                      <Td className="pf-m-truncate" dataLabel="Status" aria-labelledby="status-heading">Ready</Td>
+                      <Td
+                        className="pf-m-truncate"
+                        dataLabel="Source project"
+                        aria-labelledby="source-project-heading"
+                      >
+                        my-project
+                      </Td>
+                      <Td
+                        className="pf-m-truncate"
+                        dataLabel="Persistant volume claims"
+                        aria-labelledby="pvc-heading"
+                      >
+                        1
+                      </Td>
+                      <Td
+                        className="pf-m-truncate"
+                        dataLabel="Status"
+                        aria-labelledby="status-heading"
+                      >
+                        Ready
+                      </Td>
                     </Tr>
                   </Tbody>
                 </TableComposable>
               </GridItem>
-
             </Grid>
-
           </Tab>
 
           <Tab isDisabled eventKey={1} title={<TabTitleText>application-1</TabTitleText>}>
             stub
           </Tab>
-
         </Tabs>
-
       </PageSection>
 
       <PageSection variant="light" type="default" className={spacing.pMd}>
         <Grid hasGutter>
           <GridItem>
-            <Title headingLevel="h3">"Pipeline" history</Title>
+            <Title headingLevel="h3">&quot;Pipeline&quot; history</Title>
           </GridItem>
 
           <GridItem>
             <Toolbar>
               <ToolbarContent>
-                <ToolbarItem>filter 1</ToolbarItem>
-                <ToolbarItem>filter 2</ToolbarItem>
-                <ToolbarItem>button</ToolbarItem>
-                <ToolbarItem>button</ToolbarItem>
+                <ToolbarItem>
+                  <Dropdown
+                    onSelect={onFilter1KebabSelect}
+                    toggle={
+                      <DropdownToggle
+                        toggleIndicator={CaretDownIcon}
+                        onToggle={toggleFilter1KebabOpen}
+                        id="toggle-id-filter1"
+                      >
+                        Filter 1
+                      </DropdownToggle>
+                    }
+                    isOpen={isFilter1KebabOpen}
+                    isPlain
+                    dropdownItems={filter1DropdownItems}
+                  />
+                </ToolbarItem>
+                <ToolbarItem>
+                  <Dropdown
+                    onSelect={onFilter2KebabSelect}
+                    toggle={
+                      <DropdownToggle
+                        toggleIndicator={CaretDownIcon}
+                        onToggle={toggleFilter2KebabOpen}
+                        id="toggle-id-filter2"
+                      >
+                        Filter 2
+                      </DropdownToggle>
+                    }
+                    isOpen={isFilter2KebabOpen}
+                    isPlain
+                    dropdownItems={filter2DropdownItems}
+                  />
+                </ToolbarItem>
+                <ToolbarItem>
+                  <Button
+                    variant="primary"
+                    onClick={() => {
+                      alert('todo');
+                    }}
+                  >
+                    Button
+                  </Button>
+                </ToolbarItem>
+                <ToolbarItem>
+                  <Button
+                    variant="secondary"
+                    onClick={() => {
+                      alert('todo');
+                    }}
+                  >
+                    Button
+                  </Button>
+                </ToolbarItem>
                 <ToolbarItem>kebab-dropdown</ToolbarItem>
               </ToolbarContent>
             </Toolbar>
           </GridItem>
 
           <GridItem>
-            <TableComposable aria-label="Pipeline history" variant="compact" borders={false} gridBreakPoint="grid-md">
+            <TableComposable
+              aria-label="Pipeline history"
+              variant="compact"
+              borders={false}
+              gridBreakPoint="grid-md"
+            >
               <Thead>
-                <Th modifier="nowrap" id="pipeline-run-heading">Pipeline run</Th>
-                <Th modifier="nowrap" id="executed-heading">Executed</Th>
-                <Th modifier="nowrap" id="result-heading">Result</Th>
+                <Th modifier="nowrap" id="pipeline-run-heading">
+                  Pipeline run
+                </Th>
+                <Th modifier="nowrap" id="executed-heading">
+                  Executed
+                </Th>
+                <Th modifier="nowrap" id="result-heading">
+                  Result
+                </Th>
                 <Th modifier="nowrap" id="delete-heading"></Th>
               </Thead>
               <Tbody>
-
-                {pipelines && pipelines.data && pipelines.data.map((el) => {
-                  console.log(el);
-                  return (
-                    <Tr>
-                      <Td className="pf-m-truncate" dataLabel="Pipeline run" aria-labelledby="pipeline-run-heading">{el.metadata?.name}</Td>
-                      <Td className="pf-m-truncate" dataLabel="Executed" aria-labelledby="executed-heading">{el.metadata?.creationTimestamp}</Td>
-                      <Td className="pf-m-truncate" dataLabel="Result" aria-labelledby="result-heading">todo</Td>
-                      <Td className="pf-m-truncate" dataLabel="" aria-labelledby="delete-heading">
-                        <Button variant="secondary" onClick={() => alert('todo')}>Delete</Button>
-                      </Td>
-                    </Tr>
-                  )
-                })}
-
+                {pipelines &&
+                  pipelines.data &&
+                  pipelines.data
+                    .filter((pipeline) => pipeline.metadata?.name?.includes('-stage')) // or filter -cutover?
+                    .map((el) => {
+                      return (
+                        <Tr key={`${el.metadata?.name}`}>
+                          <Td
+                            className="pf-m-truncate"
+                            dataLabel="Pipeline run"
+                            aria-labelledby="pipeline-run-heading"
+                          >
+                            {el.metadata?.name}
+                          </Td>
+                          <Td
+                            className="pf-m-truncate"
+                            dataLabel="Executed"
+                            aria-labelledby="executed-heading"
+                          >
+                            {el.metadata?.creationTimestamp}
+                          </Td>
+                          <Td
+                            className="pf-m-truncate"
+                            dataLabel="Result"
+                            aria-labelledby="result-heading"
+                          >
+                            todo
+                          </Td>
+                          <Td
+                            className="pf-m-truncate"
+                            dataLabel=""
+                            aria-labelledby="delete-heading"
+                          >
+                            <Button
+                              variant="secondary"
+                              onClick={() =>
+                                alert(`todo implement delete for ${el.metadata?.name}`)
+                              }
+                            >
+                              Delete
+                            </Button>
+                          </Td>
+                        </Tr>
+                      );
+                    })}
               </Tbody>
             </TableComposable>
-
           </GridItem>
-
         </Grid>
       </PageSection>
     </>

--- a/src/components/AppImports/AppImports.tsx
+++ b/src/components/AppImports/AppImports.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import {
+  PageSection,
+  Tabs,
+  Tab,
+  TabTitleText,
+  Title,
+  Grid,
+  GridItem,
+  Button,
+  Dropdown,
+  KebabToggle,
+  DropdownItem,
+  Toolbar,
+  // ToolbarItem
+} from '@patternfly/react-core';
+import { TableComposable, Tbody, Thead, Tr, Th, Td } from '@patternfly/react-table';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+
+export const AppImports: React.FunctionComponent = () => {
+  // const history = useHistory();
+  const [activeTabKey, setActiveTabKey] = React.useState<string | number>(0);
+
+  const handleTabClick = (event: React.MouseEvent<HTMLElement, MouseEvent>, eventKey: string | number) => {
+    setActiveTabKey(eventKey);
+  }
+
+  const onFocus = () => {
+    const element = document.getElementById('toggle-id-0');
+    element?.focus();
+  };
+
+  const [isKebabOpen, toggleKebabOpen] = React.useReducer((isOpen) => !isOpen, false);
+
+  const onKebabSelect = (event?: React.SyntheticEvent<HTMLDivElement, Event> | undefined) => {
+    toggleKebabOpen();
+    onFocus();
+  }
+
+  const dropdownItems = [
+    <DropdownItem key="delete" component="button">Delete</DropdownItem>,
+    <DropdownItem key="view-pipelies" component="button">
+      View pipelines
+    </DropdownItem>
+  ]
+
+  return (
+    <>
+      <PageSection variant="light" type="tabs" className={spacing.pMd}>
+        <Tabs activeKey={activeTabKey} onSelect={handleTabClick} isBox>
+          <Tab eventKey={0} title={<TabTitleText>application-0</TabTitleText>}>
+
+            <Grid hasGutter className={spacing.ptMd}>
+
+              <GridItem span={6}>
+                <Title headingLevel="h3">application-0</Title>
+              </GridItem>
+
+              <GridItem span={6}>
+                <Button>Copy PVC data</Button>
+                <Button>Cutover</Button>
+                <Dropdown
+                  onSelect={onKebabSelect}
+                  toggle={<KebabToggle onToggle={toggleKebabOpen} id="toggle-id-0" />}
+                  isOpen={isKebabOpen}
+                  isPlain
+                  dropdownItems={dropdownItems}
+                />
+              </GridItem>
+
+              <GridItem>
+                <TableComposable aria-label="Application import review" variant="compact" borders={false} gridBreakPoint="grid">
+                  <Thead>
+                    <Th modifier="nowrap" id="source-project-heading">Source project</Th>
+                    <Th modifier="nowrap" id="pvc-heading">Persistant volume claims</Th>
+                    <Th modifier="nowrap" id="status-heading">Status</Th>
+                  </Thead>
+                  <Tbody>
+                    <Tr>
+                      <Td className="pf-m-truncate" dataLabel="Source project" aria-labelledby="source-project-heading">my-project</Td>
+                      <Td className="pf-m-truncate" dataLabel="Persistant volume claims" aria-labelledby="pvc-heading">1</Td>
+                      <Td className="pf-m-truncate" dataLabel="Status" aria-labelledby="status-heading">Ready</Td>
+                    </Tr>
+                  </Tbody>
+                </TableComposable>
+              </GridItem>
+
+            </Grid>
+
+          </Tab>
+
+          <Tab eventKey={1} title={<TabTitleText>application-1</TabTitleText>}>
+            stub
+          </Tab>
+
+        </Tabs>
+
+      </PageSection>
+
+      <PageSection variant="light" type="default" className={spacing.pMd}>
+        <Grid>
+          <GridItem>
+            <Title headingLevel="h3">"Pipeline" history</Title>
+          </GridItem>
+          <GridItem>
+            <Toolbar>
+              {/* toolbar items */}
+            </Toolbar>
+            <div>sortable table here</div>
+          </GridItem>
+        </Grid>
+      </PageSection>
+    </>
+  );
+};

--- a/src/components/AppImportsPage.tsx
+++ b/src/components/AppImportsPage.tsx
@@ -5,6 +5,7 @@ import { Page, PageSection, Title, TextContent, Text } from '@patternfly/react-c
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { AppImports } from './AppImports/AppImports';
 import { NamespaceContext } from 'src/context/NamespaceContext';
+import { useWatchPipelines, useWatchPipelineRuns } from 'src/api/queries/pipelines';
 
 const queryClient = new QueryClient();
 
@@ -16,27 +17,32 @@ const AppImportsPage: React.FunctionComponent<AppImportsPageProps> = ({
   match: {
     params: { namespace },
   },
-}) => (
-  <>
-    <Helmet>
-      <title>Crane - Application Imports</title>
-    </Helmet>
-    <QueryClientProvider client={queryClient}>
-      <NamespaceContext.Provider value={namespace}>
-        <Page>
-          <PageSection variant="light">
-            <TextContent>
-              <Title headingLevel="h1">Application Imports</Title>
-              <Text>
-                Select a &quot;pipeline&quot; to import an application from another cluster.
-              </Text>
-            </TextContent>
-          </PageSection>
-          <AppImports />
-        </Page>
-      </NamespaceContext.Provider>
-    </QueryClientProvider>
-  </>
-);
+}) => {
+  const pipelines = useWatchPipelines();
+  const pipelineRuns = useWatchPipelineRuns();
+
+  return (
+    <>
+      <Helmet>
+        <title>Crane - Pipeline Imports</title>
+      </Helmet>
+      <QueryClientProvider client={queryClient}>
+        <NamespaceContext.Provider value={namespace}>
+          <Page>
+            <PageSection variant="light">
+              <TextContent>
+                <Title headingLevel="h1">Pipeline Imports</Title>
+                <Text>Select a &quot;pipeline&quot; to import from another cluster.</Text>
+              </TextContent>
+            </PageSection>
+            {pipelines && pipelines.data && pipelineRuns && pipelineRuns.data && (
+              <AppImports pipelineRuns={pipelineRuns} pipelines={pipelines} />
+            )}
+          </Page>
+        </NamespaceContext.Provider>
+      </QueryClientProvider>
+    </>
+  );
+};
 
 export default AppImportsPage;

--- a/src/components/AppImportsPage.tsx
+++ b/src/components/AppImportsPage.tsx
@@ -27,7 +27,9 @@ const AppImportsPage: React.FunctionComponent<AppImportsPageProps> = ({
           <PageSection variant="light">
             <TextContent>
               <Title headingLevel="h1">Application Imports</Title>
-              <Text>Select a "pipeline" to import an application from another cluster.</Text>
+              <Text>
+                Select a &quot;pipeline&quot; to import an application from another cluster.
+              </Text>
             </TextContent>
           </PageSection>
           <AppImports />

--- a/src/components/AppImportsPage.tsx
+++ b/src/components/AppImportsPage.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import Helmet from 'react-helmet';
+import { match as RouteMatch } from 'react-router-dom';
+import { Page, PageSection, Title, TextContent, Text } from '@patternfly/react-core';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { AppImports } from './AppImports/AppImports';
+import { NamespaceContext } from 'src/context/NamespaceContext';
+
+const queryClient = new QueryClient();
+
+interface AppImportsPageProps {
+  match: RouteMatch<{ namespace: string }>;
+}
+
+const AppImportsPage: React.FunctionComponent<AppImportsPageProps> = ({
+  match: {
+    params: { namespace },
+  },
+}) => (
+  <>
+    <Helmet>
+      <title>Crane - Application Imports</title>
+    </Helmet>
+    <QueryClientProvider client={queryClient}>
+      <NamespaceContext.Provider value={namespace}>
+        <Page>
+          <PageSection variant="light">
+            <TextContent>
+              <Title headingLevel="h1">Application Imports</Title>
+              <Text>Select a "pipeline" to import an application from another cluster.</Text>
+            </TextContent>
+          </PageSection>
+          <AppImports />
+        </Page>
+      </NamespaceContext.Provider>
+    </QueryClientProvider>
+  </>
+);
+
+export default AppImportsPage;

--- a/src/utils/icons.tsx
+++ b/src/utils/icons.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
-import { ImportIcon } from '@patternfly/react-icons';
+import { ImportIcon, ApplicationsIcon } from '@patternfly/react-icons';
 
 export const importIconElement = <ImportIcon />;
+export const applicationsIconElement = <ApplicationsIcon />;


### PR DESCRIPTION
This PR adds some plumbing to make available a page for viewing/managing application imports and pipelines within the openshift console. Requirements around how we want the cutover/stage pipelines to work are still shifting a bit so this work is very much still in progress, that said it's got some decent hooks and setup in place for whichever direction it goes - @mturley if you're cool with it we can just save this work to a feature branch for now and can revive it once the dust settles on the design/UX side. Also, thanks again for the help.. these pipelines are tricky! :) 