### PR TITLE
Correct pipeline name suffix as part of SINGLE_PIPELINE_MODE

### DIFF
--- a/src/api/pipelineHelpers.ts
+++ b/src/api/pipelineHelpers.ts
@@ -21,6 +21,7 @@ export const formsToTektonResources = (
   const { pipelineName } = forms.pipelineSettings.values;
   const { selectedPVCs } = forms.pvcSelect.values;
   const isStatefulMigration = selectedPVCs.length > 0;
+  const hasMultiplePipelines = isStatefulMigration && !SINGLE_PIPELINE_MODE;
 
   const pipelineCommon: PipelineKind = {
     apiVersion: 'tekton.dev/v1beta1',
@@ -54,7 +55,7 @@ export const formsToTektonResources = (
 
   const tasks = getAllPipelineTasks(forms, namespace);
 
-  const stagePipeline: PipelineKind | null = isStatefulMigration
+  const stagePipeline: PipelineKind | null = hasMultiplePipelines
     ? {
         ...pipelineCommon,
         metadata: { name: `${pipelineName}-stage`, namespace },
@@ -73,7 +74,7 @@ export const formsToTektonResources = (
       }
     : null;
 
-  const stagePipelineRun: PipelineRunKind | null = isStatefulMigration
+  const stagePipelineRun: PipelineRunKind | null = hasMultiplePipelines
     ? {
         ...pipelineRunCommon,
         metadata: { generateName: `${pipelineName}-stage-`, namespace },
@@ -87,7 +88,7 @@ export const formsToTektonResources = (
 
   const cutoverPipeline: PipelineKind = {
     ...pipelineCommon,
-    metadata: { name: isStatefulMigration ? `${pipelineName}-cutover` : pipelineName, namespace },
+    metadata: { name: hasMultiplePipelines ? `${pipelineName}-cutover` : pipelineName, namespace },
     spec: {
       ...pipelineCommon.spec,
       workspaces: [{ name: 'shared-data' }, { name: 'kubeconfig' }],
@@ -128,12 +129,12 @@ export const formsToTektonResources = (
   const cutoverPipelineRun: PipelineRunKind = {
     ...pipelineRunCommon,
     metadata: {
-      generateName: isStatefulMigration ? `${pipelineName}-cutover-` : `${pipelineName}-`,
+      generateName: hasMultiplePipelines ? `${pipelineName}-cutover-` : `${pipelineName}-`,
       namespace,
     },
     spec: {
       ...pipelineRunCommon.spec,
-      pipelineRef: { name: isStatefulMigration ? `${pipelineName}-cutover` : pipelineName },
+      pipelineRef: { name: hasMultiplePipelines ? `${pipelineName}-cutover` : pipelineName },
       workspaces: [
         { name: 'shared-data', volumeClaimTemplate: workspaceVolumeClaimTemplate },
         { name: 'kubeconfig', volumeClaimTemplate: workspaceVolumeClaimTemplate },

--- a/src/components/ImportWizard/ImportWizardFormContext.tsx
+++ b/src/components/ImportWizard/ImportWizardFormContext.tsx
@@ -21,6 +21,7 @@ import {
 } from 'src/api/queries/sourceResources';
 import { isDefaultStorageClass, useWatchStorageClasses } from 'src/api/queries/storageClasses';
 import { useWatchPVCs } from 'src/api/queries/pvcs';
+import { SINGLE_PIPELINE_MODE } from 'src/common/constants';
 
 export const useImportWizardFormState = () => {
   // Some form field state objects are lifted out of the useFormState calls so they can reference each other
@@ -106,6 +107,7 @@ export const useImportWizardFormState = () => {
   });
 
   const isStatefulMigration = selectedPVCsField.value.length > 0;
+  const hasMultiplePipelines = isStatefulMigration && !SINGLE_PIPELINE_MODE;
 
   const pipelineNameField = useFormField(
     '',
@@ -113,7 +115,7 @@ export const useImportWizardFormState = () => {
   );
 
   const stagePipelineName = `${pipelineNameField.value}-stage`;
-  const cutoverPipelineName = isStatefulMigration
+  const cutoverPipelineName = hasMultiplePipelines
     ? `${pipelineNameField.value}-cutover`
     : pipelineNameField.value;
 


### PR DESCRIPTION
I missed a few spots where we were using the `-cutover` name suffix when I implemented `SINGLE_PIPELINE_MODE` in https://github.com/konveyor/crane-ui-plugin/pull/72.