### PR TITLE
Remove SINGLE_PIPELINE_MODE since we are committed to supporting a management page and stage pipelines for tech preview

### DIFF
--- a/src/api/pipelineHelpers.ts
+++ b/src/api/pipelineHelpers.ts
@@ -3,7 +3,6 @@ import { ImportWizardFormState } from 'src/components/ImportWizard/ImportWizardF
 import { getAllPipelineTasks } from './pipelineTaskHelpers';
 import { PipelineKind, PipelineRunKind } from '../reused/pipelines-plugin/src/types';
 import { OAuthSecret } from './types/Secret';
-import { SINGLE_PIPELINE_MODE } from 'src/common/constants';
 
 export interface WizardTektonResources {
   stagePipeline: PipelineKind | null;
@@ -21,7 +20,7 @@ export const formsToTektonResources = (
   const { pipelineName } = forms.pipelineSettings.values;
   const { selectedPVCs } = forms.pvcSelect.values;
   const isStatefulMigration = selectedPVCs.length > 0;
-  const hasMultiplePipelines = isStatefulMigration && !SINGLE_PIPELINE_MODE;
+  const hasMultiplePipelines = isStatefulMigration;
 
   const pipelineCommon: PipelineKind = {
     apiVersion: 'tekton.dev/v1beta1',
@@ -142,9 +141,6 @@ export const formsToTektonResources = (
     },
   };
 
-  if (SINGLE_PIPELINE_MODE) {
-    return { stagePipeline: null, stagePipelineRun: null, cutoverPipeline, cutoverPipelineRun };
-  }
   return { stagePipeline, stagePipelineRun, cutoverPipeline, cutoverPipelineRun };
 };
 
@@ -157,18 +153,16 @@ export const yamlToTektonResources = (
   let stagePipelineRun: PipelineRunKind | null | undefined;
   let cutoverPipeline: PipelineKind | undefined;
   let cutoverPipelineRun: PipelineRunKind | undefined;
-  if (!SINGLE_PIPELINE_MODE) {
-    try {
-      stagePipeline = stagePipelineYaml ? (yaml.load(stagePipelineYaml) as PipelineKind) : null;
-      // eslint-disable-next-line no-empty
-    } catch (e) {}
-    try {
-      stagePipelineRun = stagePipelineRunYaml
-        ? (yaml.load(stagePipelineRunYaml) as PipelineRunKind)
-        : null;
-      // eslint-disable-next-line no-empty
-    } catch (e) {}
-  }
+  try {
+    stagePipeline = stagePipelineYaml ? (yaml.load(stagePipelineYaml) as PipelineKind) : null;
+    // eslint-disable-next-line no-empty
+  } catch (e) {}
+  try {
+    stagePipelineRun = stagePipelineRunYaml
+      ? (yaml.load(stagePipelineRunYaml) as PipelineRunKind)
+      : null;
+    // eslint-disable-next-line no-empty
+  } catch (e) {}
   try {
     cutoverPipeline = yaml.load(cutoverPipelineYaml) as PipelineKind;
     // eslint-disable-next-line no-empty

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,4 +1,2 @@
 export const PROXY_SERVICE_URL = '/api/proxy/plugin/crane-ui-plugin/remote-cluster';
 export const SECRET_SERVICE_URL = '/api/proxy/plugin/crane-ui-plugin/secret-service';
-
-export const SINGLE_PIPELINE_MODE = true; // Disable/remove this after tech preview

--- a/src/components/ImportWizard/ImportWizardFormContext.tsx
+++ b/src/components/ImportWizard/ImportWizardFormContext.tsx
@@ -21,7 +21,6 @@ import {
 } from 'src/api/queries/sourceResources';
 import { isDefaultStorageClass, useWatchStorageClasses } from 'src/api/queries/storageClasses';
 import { useWatchPVCs } from 'src/api/queries/pvcs';
-import { SINGLE_PIPELINE_MODE } from 'src/common/constants';
 
 export const useImportWizardFormState = () => {
   // Some form field state objects are lifted out of the useFormState calls so they can reference each other
@@ -107,7 +106,7 @@ export const useImportWizardFormState = () => {
   });
 
   const isStatefulMigration = selectedPVCsField.value.length > 0;
-  const hasMultiplePipelines = isStatefulMigration && !SINGLE_PIPELINE_MODE;
+  const hasMultiplePipelines = isStatefulMigration;
 
   const pipelineNameField = useFormField(
     '',

--- a/src/components/ImportWizard/ReviewStep.tsx
+++ b/src/components/ImportWizard/ReviewStep.tsx
@@ -25,13 +25,12 @@ import { yamlToTektonResources } from 'src/api/pipelineHelpers';
 import { PipelineVisualizationWrapper } from 'src/common/components/PipelineVisualizationWrapper';
 import { columnNames as pvcColumnNames } from './PVCEditStep';
 import { getYamlFieldKeys, YamlFieldKey } from './helpers';
-import { SINGLE_PIPELINE_MODE } from 'src/common/constants';
 
 export const ReviewStep: React.FunctionComponent = () => {
   const forms = React.useContext(ImportWizardFormContext);
   const { pipelineName } = forms.pipelineSettings.values;
   const isStatefulMigration = forms.pvcSelect.values.selectedPVCs.length > 0;
-  const hasMultiplePipelines = isStatefulMigration && !SINGLE_PIPELINE_MODE;
+  const hasMultiplePipelines = isStatefulMigration;
   const { stagePipeline, cutoverPipeline } = yamlToTektonResources(forms);
 
   // TODO warn somehow if the user is going to override their manual edits here when they go to another step (use isTouched)? not sure how to do that if they use canJumpTo


### PR DESCRIPTION
We previously added this `SINGLE_PIPELINE_MODE` flag to simplify the UI by not generating a pipeline for the stage action on a stateful app migration, in order to avoid confusion when seeing multiple pipelines in the Tekton UI after submitting the wizard.

Now that we are committed to adding a management page to simplify multiple actions after a single wizard run (stage and cutover, and eventually rollback) we can revert this and go back to generating multiple pipelines. Doing this now rather than when the management page is available so that QE can get started automating the wizard as it will be at release time.