### PR TITLE
Add confirmation modals on stage/cutover/delete, properly restrict actions in certain conditions

### DIFF
--- a/src/api/queries/pipelines.ts
+++ b/src/api/queries/pipelines.ts
@@ -21,7 +21,9 @@ import {
   CranePipelineGroup,
   CranePipelineRun,
   CRANE_PIPELINE_ACTIONS,
+  PipelineRunStatusString,
 } from '../types/CranePipeline';
+import { pipelineRunStatus } from 'src/reused/pipelines-plugin/src/utils/pipeline-filter-reducer';
 
 export const pipelineGVK: K8sGroupVersionKind = {
   group: 'tekton.dev',
@@ -240,3 +242,12 @@ export const isMissingPipelineRuns = (pipelineGroup?: CranePipelineGroup) => {
       !!pipelineGroup.pipelines[action] && pipelineGroup.pipelineRuns[action].length === 0,
   );
 };
+
+export const hasRunWithStatus = (
+  pipelineGroup: CranePipelineGroup,
+  action: CranePipelineAction,
+  status: PipelineRunStatusString,
+) => !!pipelineGroup.pipelineRuns[action].find((plr) => pipelineRunStatus(plr) === status);
+
+export const isSomePipelineRunning = (pipelineGroup: CranePipelineGroup) =>
+  CRANE_PIPELINE_ACTIONS.some((a) => hasRunWithStatus(pipelineGroup, a, 'Running'));

--- a/src/api/queries/pipelines.ts
+++ b/src/api/queries/pipelines.ts
@@ -187,7 +187,7 @@ export const useStartPipelineRunMutation = (
         kind: 'PipelineRun',
         spec: { ...latestPipelineRun.spec },
         metadata: {
-          generateName: pipeline.metadata?.name || '',
+          generateName: `${pipeline.metadata?.name || ''}-`,
           namespace: pipeline.metadata.namespace,
           ownerReferences: latestPipelineRun.metadata?.ownerReferences,
           annotations: pipeline.metadata.annotations,

--- a/src/api/queries/pipelines.ts
+++ b/src/api/queries/pipelines.ts
@@ -21,9 +21,11 @@ import {
   CranePipelineGroup,
   CranePipelineRun,
   CRANE_PIPELINE_ACTIONS,
-  PipelineRunStatusString,
 } from '../types/CranePipeline';
-import { pipelineRunStatus } from 'src/reused/pipelines-plugin/src/utils/pipeline-filter-reducer';
+import {
+  pipelineRunStatus,
+  PipelineRunStatusString,
+} from 'src/reused/pipelines-plugin/src/utils/pipeline-filter-reducer';
 
 export const pipelineGVK: K8sGroupVersionKind = {
   group: 'tekton.dev',
@@ -229,10 +231,8 @@ export const isPipelineRunStarting = (
   mutation.isLoading ||
   (mutation.isSuccess &&
     !isMissingPipelineRuns(pipelineGroup) &&
-    !pipelineGroup.pipelineRuns.all.find(
-      (plr) =>
-        plr.metadata?.name === mutation.data?.metadata.name &&
-        plr.spec.status !== 'PipelineRunPending',
+    !pipelineGroup.pipelineRuns.nonPending.find(
+      (plr) => plr.metadata?.name === mutation.data?.metadata.name,
     ));
 
 export const isMissingPipelineRuns = (pipelineGroup?: CranePipelineGroup) => {
@@ -251,3 +251,7 @@ export const hasRunWithStatus = (
 
 export const isSomePipelineRunning = (pipelineGroup: CranePipelineGroup) =>
   CRANE_PIPELINE_ACTIONS.some((a) => hasRunWithStatus(pipelineGroup, a, 'Running'));
+
+export const hasRunningOrSucceededCutover = (pipelineGroup: CranePipelineGroup) =>
+  hasRunWithStatus(pipelineGroup, 'cutover', 'Running') ||
+  hasRunWithStatus(pipelineGroup, 'cutover', 'Succeeded');

--- a/src/api/queries/pipelines.ts
+++ b/src/api/queries/pipelines.ts
@@ -251,7 +251,3 @@ export const hasRunWithStatus = (
 
 export const isSomePipelineRunning = (pipelineGroup: CranePipelineGroup) =>
   CRANE_PIPELINE_ACTIONS.some((a) => hasRunWithStatus(pipelineGroup, a, 'Running'));
-
-export const hasRunningOrSucceededCutover = (pipelineGroup: CranePipelineGroup) =>
-  hasRunWithStatus(pipelineGroup, 'cutover', 'Running') ||
-  hasRunWithStatus(pipelineGroup, 'cutover', 'Succeeded');

--- a/src/api/queries/pipelines.ts
+++ b/src/api/queries/pipelines.ts
@@ -191,7 +191,7 @@ export const useStartPipelineRunMutation = (
         kind: 'PipelineRun',
         spec: { ...latestPipelineRun.spec },
         metadata: {
-          generateName: `${pipeline.metadata?.name || ''}-`,
+          generateName: `${pipeline.metadata?.name}-`,
           namespace: pipeline.metadata.namespace,
           ownerReferences: latestPipelineRun.metadata?.ownerReferences,
           annotations: pipeline.metadata.annotations,

--- a/src/api/queries/pipelines.ts
+++ b/src/api/queries/pipelines.ts
@@ -100,7 +100,7 @@ export const useWatchCranePipelineGroups = () => {
         nonPending: nonPendingPipelineRunsInGroup,
         latestNonPending: latestNonPendingPipelineRun,
       },
-      isStatefulApp: !!stagePipeline,
+      isStatefulMigration: !!stagePipeline,
     };
   });
 

--- a/src/api/types/CranePipeline.ts
+++ b/src/api/types/CranePipeline.ts
@@ -31,11 +31,3 @@ export interface CranePipelineGroup {
   };
   isStatefulMigration: boolean;
 }
-
-export type PipelineRunStatusString =
-  | 'Running'
-  | 'Succeeded'
-  | 'Failed'
-  | 'Cancelled'
-  | 'Pending'
-  | 'Skipped';

--- a/src/api/types/CranePipeline.ts
+++ b/src/api/types/CranePipeline.ts
@@ -31,3 +31,11 @@ export interface CranePipelineGroup {
   };
   isStatefulMigration: boolean;
 }
+
+export type PipelineRunStatusString =
+  | 'Running'
+  | 'Succeeded'
+  | 'Failed'
+  | 'Cancelled'
+  | 'Pending'
+  | 'Skipped';

--- a/src/api/types/CranePipeline.ts
+++ b/src/api/types/CranePipeline.ts
@@ -29,4 +29,5 @@ export interface CranePipelineGroup {
     nonPending: CranePipelineRun[];
     latestNonPending: CranePipelineRun | null;
   };
+  isStatefulApp: boolean;
 }

--- a/src/api/types/CranePipeline.ts
+++ b/src/api/types/CranePipeline.ts
@@ -29,5 +29,5 @@ export interface CranePipelineGroup {
     nonPending: CranePipelineRun[];
     latestNonPending: CranePipelineRun | null;
   };
-  isStatefulApp: boolean;
+  isStatefulMigration: boolean;
 }

--- a/src/common/components/ConfirmModal.tsx
+++ b/src/common/components/ConfirmModal.tsx
@@ -52,7 +52,7 @@ export const ConfirmModal: React.FunctionComponent<IConfirmModalProps> = ({
       onClose={toggleOpen}
       footer={
         <Stack hasGutter>
-          {mutateResult ? (
+          {mutateResult?.isError ? (
             <ResolvedQuery result={mutateResult} errorTitle={errorText} spinnerMode="inline" />
           ) : null}
           <Flex spaceItems={{ default: 'spaceItemsSm' }}>

--- a/src/common/components/ConfirmModal.tsx
+++ b/src/common/components/ConfirmModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Modal, Stack, Flex, Button, ModalProps } from '@patternfly/react-core';
+import { Modal, Stack, Flex, Button, ModalProps, ButtonProps } from '@patternfly/react-core';
 import { ResolvedQuery } from '@konveyor/lib-ui';
 import { UseMutationResult, UseQueryResult } from 'react-query';
 
@@ -26,8 +26,9 @@ export interface IConfirmModalProps {
   title: string;
   body: React.ReactNode;
   confirmButtonText: string;
-  cancelButtonText?: string;
   confirmButtonDisabled?: boolean;
+  confirmButtonVariant?: ButtonProps['variant'];
+  cancelButtonText?: string;
   errorText?: string;
 }
 
@@ -41,6 +42,7 @@ export const ConfirmModal: React.FunctionComponent<IConfirmModalProps> = ({
   body,
   confirmButtonText,
   confirmButtonDisabled = false,
+  confirmButtonVariant = 'primary',
   cancelButtonText = 'Cancel',
   errorText = 'Error performing action',
 }: IConfirmModalProps) =>
@@ -59,7 +61,7 @@ export const ConfirmModal: React.FunctionComponent<IConfirmModalProps> = ({
             <Button
               id="modal-confirm-button"
               key="confirm"
-              variant="primary"
+              variant={confirmButtonVariant}
               onClick={mutateFn}
               isDisabled={mutateResult?.isLoading || confirmButtonDisabled}
             >

--- a/src/common/components/PipelineExplanation.tsx
+++ b/src/common/components/PipelineExplanation.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { TextContent, TextList, TextListItem, Text } from '@patternfly/react-core';
+import { CranePipelineAction } from 'src/api/types/CranePipeline';
+
+interface PipelineExplanationProps {
+  action: CranePipelineAction;
+  isStatefulMigration: boolean;
+}
+
+export const PipelineExplanation: React.FunctionComponent<PipelineExplanationProps> = ({
+  action,
+  isStatefulMigration,
+}) => {
+  if (action === 'stage') {
+    return (
+      <TextContent>
+        <Text component="p">During a stage migration:</Text>
+        <TextList>
+          <TextListItem>PVC data is synchronized into the active project.</TextListItem>
+          <TextListItem>
+            Workloads are not migrated and remain running in the source cluster.
+          </TextListItem>
+        </TextList>
+        <Text component="p">
+          The stage pipeline can be re-run multiple times to lower the downtime of a subsequent
+          cutover.
+        </Text>
+      </TextContent>
+    );
+  }
+  if (action === 'cutover') {
+    return (
+      <TextContent>
+        <Text component="p">During a cutover migration:</Text>
+        <TextList>
+          <TextListItem>All applications on the source namespace are halted.</TextListItem>
+          {isStatefulMigration ? (
+            <TextListItem>PVC data is migrated into the active project.</TextListItem>
+          ) : null}
+          <TextListItem>Workloads are migrated into the active project.</TextListItem>
+        </TextList>
+        <Text component="p">The cutover pipeline is the final step in an import.</Text>
+      </TextContent>
+    );
+  }
+  return null;
+};

--- a/src/common/components/PipelineExplanation.tsx
+++ b/src/common/components/PipelineExplanation.tsx
@@ -5,16 +5,21 @@ import { CranePipelineAction } from 'src/api/types/CranePipeline';
 interface PipelineExplanationProps {
   action: CranePipelineAction;
   isStatefulMigration: boolean;
+  hasVisualization?: boolean;
 }
 
 export const PipelineExplanation: React.FunctionComponent<PipelineExplanationProps> = ({
   action,
   isStatefulMigration,
+  hasVisualization = false,
 }) => {
   if (action === 'stage') {
     return (
       <TextContent>
-        <Text component="p">During a stage migration:</Text>
+        <Text component="p">
+          {hasVisualization ? 'This shows the pipeline tasks for a stage import. ' : ''}
+          During a stage import:
+        </Text>
         <TextList>
           <TextListItem>PVC data is synchronized into the active project.</TextListItem>
           <TextListItem>
@@ -23,7 +28,7 @@ export const PipelineExplanation: React.FunctionComponent<PipelineExplanationPro
         </TextList>
         <Text component="p">
           The stage pipeline can be re-run multiple times to lower the downtime of a subsequent
-          cutover.
+          cutover import.
         </Text>
       </TextContent>
     );
@@ -31,7 +36,10 @@ export const PipelineExplanation: React.FunctionComponent<PipelineExplanationPro
   if (action === 'cutover') {
     return (
       <TextContent>
-        <Text component="p">During a cutover migration:</Text>
+        <Text component="p">
+          {hasVisualization ? 'This shows the pipeline tasks for a cutover import. ' : ''}
+          During a cutover import:
+        </Text>
         <TextList>
           <TextListItem>All applications on the source namespace are halted.</TextListItem>
           {isStatefulMigration ? (
@@ -39,7 +47,9 @@ export const PipelineExplanation: React.FunctionComponent<PipelineExplanationPro
           ) : null}
           <TextListItem>Workloads are migrated into the active project.</TextListItem>
         </TextList>
-        <Text component="p">The cutover pipeline is the final step in an import.</Text>
+        {isStatefulMigration ? (
+          <Text component="p">The cutover pipeline is the final step in a migration project.</Text>
+        ) : null}
       </TextContent>
     );
   }

--- a/src/common/components/PipelineExplanation.tsx
+++ b/src/common/components/PipelineExplanation.tsx
@@ -17,8 +17,9 @@ export const PipelineExplanation: React.FunctionComponent<PipelineExplanationPro
     return (
       <TextContent>
         <Text component="p">
-          {hasVisualization ? 'This shows the pipeline tasks for a stage import. ' : ''}
-          During a stage import:
+          {hasVisualization
+            ? 'This shows the pipeline tasks for the stage phase of an import. During the stage phase:'
+            : 'During the stage phase of an import:'}
         </Text>
         <TextList>
           <TextListItem>PVC data is synchronized into the active project.</TextListItem>
@@ -37,8 +38,9 @@ export const PipelineExplanation: React.FunctionComponent<PipelineExplanationPro
     return (
       <TextContent>
         <Text component="p">
-          {hasVisualization ? 'This shows the pipeline tasks for a cutover import. ' : ''}
-          During a cutover import:
+          {hasVisualization
+            ? 'This shows the pipeline tasks for the cutover phase of an import. During the cutover phase:'
+            : 'During the cutover phase of an import:'}
         </Text>
         <TextList>
           <TextListItem>All applications on the source namespace are halted.</TextListItem>

--- a/src/components/AppImports/PipelineGroupActionButton.tsx
+++ b/src/components/AppImports/PipelineGroupActionButton.tsx
@@ -6,7 +6,7 @@ import {
   isPipelineRunStarting,
   isMissingPipelineRuns,
   isSomePipelineRunning,
-  hasRunningOrSucceededCutover,
+  hasRunWithStatus,
 } from 'src/api/queries/pipelines';
 import { CranePipelineAction, CranePipelineGroup } from 'src/api/types/CranePipeline';
 import { actionToString } from 'src/api/pipelineHelpers';
@@ -32,7 +32,7 @@ export const PipelineGroupActionButton: React.FunctionComponent<PipelineGroupAct
   const isStarting = isPipelineRunStarting(pipelineGroup, mutation);
   const isGroupBroken = isMissingPipelineRuns(pipelineGroup);
   const isRunning = isSomePipelineRunning(pipelineGroup);
-  const isPastCutover = hasRunningOrSucceededCutover(pipelineGroup);
+  const isPastCutover = hasRunWithStatus(pipelineGroup, 'cutover', 'Succeeded');
   const isDisabled = isStarting || isGroupBroken || isRunning || isPastCutover;
 
   React.useEffect(() => {
@@ -67,7 +67,7 @@ export const PipelineGroupActionButton: React.FunctionComponent<PipelineGroupAct
   ) : isRunning ? (
     <>A stage or cutover cannot be started while one is already running.</>
   ) : isPastCutover ? (
-    <>A {action} cannot be run after a cutover is already running or succeeded.</>
+    <>A stage or cutover cannot be run after a cutover is already succeeded.</>
   ) : null;
 
   return (

--- a/src/components/AppImports/PipelineGroupActionButton.tsx
+++ b/src/components/AppImports/PipelineGroupActionButton.tsx
@@ -33,8 +33,7 @@ export const PipelineGroupActionButton: React.FunctionComponent<PipelineGroupAct
   const isGroupBroken = isMissingPipelineRuns(pipelineGroup);
   const isRunning = isSomePipelineRunning(pipelineGroup);
   const isPastCutover = hasRunningOrSucceededCutover(pipelineGroup);
-  const isDisabled =
-    isStarting || isGroupBroken || isRunning || (action === 'stage' && isPastCutover);
+  const isDisabled = isStarting || isGroupBroken || isRunning || isPastCutover;
 
   React.useEffect(() => {
     // Don't keep old mutation state around in case relevant resources get deleted and mess with isStarting
@@ -67,8 +66,8 @@ export const PipelineGroupActionButton: React.FunctionComponent<PipelineGroupAct
     </>
   ) : isRunning ? (
     <>A stage or cutover cannot be started while one is already running.</>
-  ) : action === 'stage' && isPastCutover ? (
-    <>A stage cannot be run after a cutover is already running or succeeded.</>
+  ) : isPastCutover ? (
+    <>A {action} cannot be run after a cutover is already running or succeeded.</>
   ) : null;
 
   return (

--- a/src/components/AppImports/PipelineGroupActionButton.tsx
+++ b/src/components/AppImports/PipelineGroupActionButton.tsx
@@ -1,14 +1,5 @@
 import * as React from 'react';
-import {
-  Button,
-  ButtonProps,
-  TextContent,
-  Text,
-  TextList,
-  TextListItem,
-  Title,
-  Tooltip,
-} from '@patternfly/react-core';
+import { Button, ButtonProps, Tooltip } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import {
   isMissingPipelineRuns,
@@ -18,6 +9,7 @@ import {
 import { CranePipelineAction, CranePipelineGroup } from 'src/api/types/CranePipeline';
 import { actionToString } from 'src/api/pipelineHelpers';
 import { ConfirmModal } from 'src/common/components/ConfirmModal';
+import { PipelineExplanation } from 'src/common/components/PipelineExplanation';
 
 interface PipelineGroupActionButtonProps {
   pipelineGroup: CranePipelineGroup;
@@ -70,46 +62,17 @@ export const PipelineGroupActionButton: React.FunctionComponent<PipelineGroupAct
     </>
   ) : null;
 
-  const confirmMessagesByAction: Record<CranePipelineAction, React.ReactNode> = {
-    stage: (
-      <TextContent>
-        <Title headingLevel="h2" size="md">
-          During a stage migration:
-        </Title>
-        <TextList>
-          <TextListItem>PVC data is synchronized into the active project.</TextListItem>
-          <TextListItem>
-            Workloads are not migrated and remain running in the source cluster.
-          </TextListItem>
-        </TextList>
-        <Text component="p">
-          The stage pipeline can be re-run multiple times to lower the downtime of a subsequent
-          cutover.
-        </Text>
-      </TextContent>
-    ),
-    cutover: (
-      <TextContent>
-        <Title headingLevel="h2" size="md">
-          During a cutover migration:
-        </Title>
-        <TextList>
-          <TextListItem>All applications on the source namespace are halted.</TextListItem>
-          {pipelineGroup.isStatefulApp ? (
-            <TextListItem>PVC data is migrated into the active project.</TextListItem>
-          ) : null}
-          <TextListItem>Workloads are migrated into the active project.</TextListItem>
-        </TextList>
-      </TextContent>
-    ),
-  };
-
   return (
     <>
       {disabledReason ? <Tooltip content={disabledReason}>{button}</Tooltip> : button}
       <ConfirmModal
         title={`Run ${action}?`}
-        body={confirmMessagesByAction[action]}
+        body={
+          <PipelineExplanation
+            action={action}
+            isStatefulMigration={pipelineGroup.isStatefulMigration}
+          />
+        }
         confirmButtonText={actionToString(action)}
         isOpen={isConfirmModalOpen}
         toggleOpen={() => setIsConfirmModalOpen(!isConfirmModalOpen)}

--- a/src/components/AppImports/PipelineGroupActionButton.tsx
+++ b/src/components/AppImports/PipelineGroupActionButton.tsx
@@ -2,17 +2,13 @@ import * as React from 'react';
 import { Button, ButtonProps, Tooltip } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import {
-  hasRunWithStatus,
-  isMissingPipelineRuns,
-  isPipelineRunStarting,
-  isSomePipelineRunning,
   useStartPipelineRunMutation,
+  isPipelineRunStarting,
+  isMissingPipelineRuns,
+  isSomePipelineRunning,
+  hasRunningOrSucceededCutover,
 } from 'src/api/queries/pipelines';
-import {
-  CranePipelineAction,
-  CranePipelineGroup,
-  PipelineRunStatusString,
-} from 'src/api/types/CranePipeline';
+import { CranePipelineAction, CranePipelineGroup } from 'src/api/types/CranePipeline';
 import { actionToString } from 'src/api/pipelineHelpers';
 import { ConfirmModal } from 'src/common/components/ConfirmModal';
 import { PipelineExplanation } from 'src/common/components/PipelineExplanation';
@@ -34,11 +30,9 @@ export const PipelineGroupActionButton: React.FunctionComponent<PipelineGroupAct
     onSuccess: () => setIsConfirmModalOpen(false),
   });
   const isStarting = isPipelineRunStarting(pipelineGroup, mutation);
-  const isRunning = isSomePipelineRunning(pipelineGroup);
-  const isPastCutover = (['Running', 'Succeeded'] as PipelineRunStatusString[]).some((status) =>
-    hasRunWithStatus(pipelineGroup, 'cutover', status),
-  );
   const isGroupBroken = isMissingPipelineRuns(pipelineGroup);
+  const isRunning = isSomePipelineRunning(pipelineGroup);
+  const isPastCutover = hasRunningOrSucceededCutover(pipelineGroup);
   const isDisabled =
     isStarting || isGroupBroken || isRunning || (action === 'stage' && isPastCutover);
 

--- a/src/components/AppImports/PipelineGroupHistoryTable.tsx
+++ b/src/components/AppImports/PipelineGroupHistoryTable.tsx
@@ -50,40 +50,34 @@ export const PipelineGroupHistoryTable: React.FunctionComponent<PipelineGroupHis
             </Tr>
           </Thead>
           <Tbody>
-            {pipelineGroup.pipelineRuns.all
-              .filter((pipelineRun) => pipelineRun.spec.status !== 'PipelineRunPending')
-              .map((pipelineRun) => (
-                <Tr key={`${pipelineRun.metadata?.name}`}>
-                  <Td
-                    className="pf-m-truncate"
-                    dataLabel="Pipeline run"
-                    aria-labelledby="pipeline-run-heading"
-                  >
-                    <Link to={pipelineRunUrl(namespace, pipelineRun)}>
-                      {pipelineRun.metadata?.name}
-                    </Link>
-                  </Td>
-                  <Td className="pf-m-truncate" dataLabel="Action" aria-labelledby="action-heading">
-                    {resourceActionToString(pipelineRun)}
-                  </Td>
-                  <Td
-                    className="pf-m-truncate"
-                    dataLabel="Started"
-                    aria-labelledby="started-heading"
-                  >
-                    {pipelineRun.status?.startTime ? (
-                      <Timestamp timestamp={pipelineRun.status?.startTime} />
-                    ) : (
-                      'Not started'
-                    )}
-                  </Td>
-                  <Td className="pf-m-truncate" dataLabel="Status" aria-labelledby="result-heading">
-                    <Link to={pipelineRunUrl(namespace, pipelineRun)}>
-                      <PipelineRunStatus pipelineRun={pipelineRun} />
-                    </Link>
-                  </Td>
-                </Tr>
-              ))}
+            {pipelineGroup.pipelineRuns.nonPending.map((pipelineRun) => (
+              <Tr key={`${pipelineRun.metadata?.name}`}>
+                <Td
+                  className="pf-m-truncate"
+                  dataLabel="Pipeline run"
+                  aria-labelledby="pipeline-run-heading"
+                >
+                  <Link to={pipelineRunUrl(namespace, pipelineRun)}>
+                    {pipelineRun.metadata?.name}
+                  </Link>
+                </Td>
+                <Td className="pf-m-truncate" dataLabel="Action" aria-labelledby="action-heading">
+                  {resourceActionToString(pipelineRun)}
+                </Td>
+                <Td className="pf-m-truncate" dataLabel="Started" aria-labelledby="started-heading">
+                  {pipelineRun.status?.startTime ? (
+                    <Timestamp timestamp={pipelineRun.status?.startTime} />
+                  ) : (
+                    'Not started'
+                  )}
+                </Td>
+                <Td className="pf-m-truncate" dataLabel="Status" aria-labelledby="result-heading">
+                  <Link to={pipelineRunUrl(namespace, pipelineRun)}>
+                    <PipelineRunStatus pipelineRun={pipelineRun} />
+                  </Link>
+                </Td>
+              </Tr>
+            ))}
           </Tbody>
         </TableComposable>
       )}

--- a/src/components/AppImports/PipelineGroupKebabMenu.tsx
+++ b/src/components/AppImports/PipelineGroupKebabMenu.tsx
@@ -6,6 +6,7 @@ import { CranePipelineGroup } from 'src/api/types/CranePipeline';
 import { useDeletePipelineMutation } from 'src/api/queries/pipelines';
 import { useNamespaceContext } from 'src/context/NamespaceContext';
 import { pipelinesListUrl } from 'src/utils/paths';
+import { ConfirmModal } from 'src/common/components/ConfirmModal';
 
 interface PipelineGroupKebabMenuProps {
   pipelineGroup: CranePipelineGroup;
@@ -31,33 +32,50 @@ export const PipelineGroupKebabMenu: React.FunctionComponent<PipelineGroupKebabM
     onFocus('toggle-id-app-kebab');
   };
 
+  const [isConfirmDeleteModalOpen, setIsConfirmDeleteModalOpen] = React.useState(false);
+
   return (
-    <Dropdown
-      onSelect={onAppKebabSelect}
-      toggle={<KebabToggle onToggle={toggleAppKebabOpen} id="toggle-id-app-kebab" />}
-      isOpen={isAppKebabOpen}
-      isPlain
-      position="right"
-      dropdownItems={[
-        <DropdownItem
-          key="app-delete"
-          component="button"
-          onClick={() =>
-            // TODO add a confirmation dialog!
-            deletePipelineMutation.mutate(pipelineGroup.pipelines.cutover)
-          }
-          isDisabled={deletePipelineMutation.isLoading}
-        >
-          Delete
-        </DropdownItem>,
-        <DropdownItem
-          key="app-view-pipelies"
-          component="button"
-          onClick={() => history.push(pipelinesListUrl(namespace, pipelineGroup.name))}
-        >
-          View pipelines
-        </DropdownItem>,
-      ]}
-    />
+    <>
+      <Dropdown
+        onSelect={onAppKebabSelect}
+        toggle={<KebabToggle onToggle={toggleAppKebabOpen} id="toggle-id-app-kebab" />}
+        isOpen={isAppKebabOpen}
+        isPlain
+        position="right"
+        dropdownItems={[
+          <DropdownItem
+            key="app-delete"
+            component="button"
+            onClick={() => setIsConfirmDeleteModalOpen(true)}
+            isDisabled={deletePipelineMutation.isLoading}
+          >
+            Delete
+          </DropdownItem>,
+          <DropdownItem
+            key="app-view-pipelies"
+            component="button"
+            onClick={() => history.push(pipelinesListUrl(namespace, pipelineGroup.name))}
+          >
+            View pipelines
+          </DropdownItem>,
+        ]}
+      />
+      <ConfirmModal
+        title="Delete pipelines and history?"
+        body={
+          <>
+            This will delete all Pipelines, PipelineRuns and Secrets that were created with the
+            group name <strong>&quot;{pipelineGroup.name}&quot;</strong>. All related logs and
+            history will be lost.
+          </>
+        }
+        confirmButtonText="Delete"
+        isOpen={isConfirmDeleteModalOpen}
+        toggleOpen={() => setIsConfirmDeleteModalOpen(!isConfirmDeleteModalOpen)}
+        mutateFn={() => deletePipelineMutation.mutate(pipelineGroup.pipelines.cutover)}
+        mutateResult={deletePipelineMutation}
+        errorText="Cannot delete resources"
+      />
+    </>
   );
 };

--- a/src/components/AppImports/PipelineGroupKebabMenu.tsx
+++ b/src/components/AppImports/PipelineGroupKebabMenu.tsx
@@ -80,6 +80,7 @@ export const PipelineGroupKebabMenu: React.FunctionComponent<PipelineGroupKebabM
           </>
         }
         confirmButtonText="Delete"
+        confirmButtonVariant="danger"
         isOpen={isConfirmDeleteModalOpen}
         toggleOpen={() => setIsConfirmDeleteModalOpen(!isConfirmDeleteModalOpen)}
         mutateFn={() => deletePipelineMutation.mutate(pipelineGroup.pipelines.cutover)}

--- a/src/components/AppImports/PipelineGroupKebabMenu.tsx
+++ b/src/components/AppImports/PipelineGroupKebabMenu.tsx
@@ -55,7 +55,7 @@ export const PipelineGroupKebabMenu: React.FunctionComponent<PipelineGroupKebabM
         position="right"
         dropdownItems={[
           isRunning ? (
-            <Tooltip content="The import pipelines cannot be deleted while one is running">
+            <Tooltip content="The import pipelines cannot be deleted while one is running.">
               {deleteItem}
             </Tooltip>
           ) : (

--- a/src/components/AppImports/PipelineGroupKebabMenu.tsx
+++ b/src/components/AppImports/PipelineGroupKebabMenu.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
-import { Dropdown, KebabToggle, DropdownItem } from '@patternfly/react-core';
+import { Dropdown, KebabToggle, DropdownItem, Tooltip } from '@patternfly/react-core';
 
 import { CranePipelineGroup } from 'src/api/types/CranePipeline';
-import { useDeletePipelineMutation } from 'src/api/queries/pipelines';
+import { isSomePipelineRunning, useDeletePipelineMutation } from 'src/api/queries/pipelines';
 import { useNamespaceContext } from 'src/context/NamespaceContext';
 import { pipelinesListUrl } from 'src/utils/paths';
 import { ConfirmModal } from 'src/common/components/ConfirmModal';
@@ -33,6 +33,17 @@ export const PipelineGroupKebabMenu: React.FunctionComponent<PipelineGroupKebabM
   };
 
   const [isConfirmDeleteModalOpen, setIsConfirmDeleteModalOpen] = React.useState(false);
+  const isRunning = isSomePipelineRunning(pipelineGroup);
+  const deleteItem = (
+    <DropdownItem
+      key="app-delete"
+      component="button"
+      onClick={() => setIsConfirmDeleteModalOpen(true)}
+      isAriaDisabled={deletePipelineMutation.isLoading || isRunning}
+    >
+      Delete
+    </DropdownItem>
+  );
 
   return (
     <>
@@ -43,14 +54,13 @@ export const PipelineGroupKebabMenu: React.FunctionComponent<PipelineGroupKebabM
         isPlain
         position="right"
         dropdownItems={[
-          <DropdownItem
-            key="app-delete"
-            component="button"
-            onClick={() => setIsConfirmDeleteModalOpen(true)}
-            isDisabled={deletePipelineMutation.isLoading}
-          >
-            Delete
-          </DropdownItem>,
+          isRunning ? (
+            <Tooltip content="The import pipelines cannot be deleted while one is running">
+              {deleteItem}
+            </Tooltip>
+          ) : (
+            deleteItem
+          ),
           <DropdownItem
             key="app-view-pipelies"
             component="button"

--- a/src/components/AppImportsPage.tsx
+++ b/src/components/AppImportsPage.tsx
@@ -119,7 +119,7 @@ const AppImportsPage: React.FunctionComponent<AppImportsPageProps> = ({
             <Title headingLevel="h1">Application Imports</Title>
             <Text>View status and take actions on your application import pipelines.</Text>
           </TextContent>
-          {namespace !== '#ALL_NS#' && !isEmptyState ? (
+          {!isAllNamespaces && !isEmptyState ? (
             <Button variant="secondary" className={spacing.mxMd} onClick={goToImportWizard}>
               Start a new import
             </Button>

--- a/src/components/ImportWizard/ImportWizard.css
+++ b/src/components/ImportWizard/ImportWizard.css
@@ -15,3 +15,11 @@
 #crane-import-wizard .advanced-switch .pf-c-switch__label {
   font-weight: normal;
 }
+
+#crane-import-wizard .pipeline-info-help-icon {
+  color: var(--pf-global--Color--200);
+}
+
+#crane-import-wizard .pipeline-info-help-icon:hover {
+  color: var(--pf-global--Color--100);
+}

--- a/src/components/ImportWizard/ReviewStep.tsx
+++ b/src/components/ImportWizard/ReviewStep.tsx
@@ -11,13 +11,11 @@ import {
   Button,
   Popover,
   Title,
-  List,
-  ListItem,
 } from '@patternfly/react-core';
 import { CodeEditor, Language } from '@patternfly/react-code-editor';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import QuestionCircle from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';
+import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 
 import { SimpleSelectMenu } from 'src/common/components/SimpleSelectMenu';
 import { ImportWizardFormContext } from './ImportWizardFormContext';
@@ -25,6 +23,7 @@ import { yamlToTektonResources } from 'src/api/pipelineHelpers';
 import { PipelineVisualizationWrapper } from 'src/common/components/PipelineVisualizationWrapper';
 import { columnNames as pvcColumnNames } from './PVCEditStep';
 import { getYamlFieldKeys, YamlFieldKey } from './helpers';
+import { PipelineExplanation } from 'src/common/components/PipelineExplanation';
 
 export const ReviewStep: React.FunctionComponent = () => {
   const forms = React.useContext(ImportWizardFormContext);
@@ -184,36 +183,25 @@ export const ReviewStep: React.FunctionComponent = () => {
       {hasMultiplePipelines ? (
         <>
           <TextContent className={spacing.mbSm}>
-            <Title headingLevel="h3" size="xl">
+            <Title headingLevel="h3" size="lg">
               {stagePipelineName}
-
               <Popover
+                hasAutoWidth
                 bodyContent={
-                  <TextContent>
-                    <Text>
-                      This shows the pipeline tasks for a stage import. During a stage import:
-                    </Text>
-                    <List>
-                      <ListItem>PVC data is synchronized into the active project.</ListItem>
-                      <ListItem>
-                        Workloads are not migrated and remain running in the source cluster.
-                      </ListItem>
-                    </List>
-                    <Text>
-                      A stage pipeline can be re-run multiple times to lower the downtime of a
-                      subsequent cutover import.
-                    </Text>
-                  </TextContent>
+                  <PipelineExplanation
+                    action="stage"
+                    isStatefulMigration={isStatefulMigration}
+                    hasVisualization
+                  />
                 }
               >
                 <Button
-                  aria-label="More info for visualization pipeline field"
+                  aria-label={`More info for ${stagePipelineName} pipeline visualization`}
                   variant="link"
                   isInline
-                  className="pf-u-ml-sm"
-                  style={{ color: 'var(--pf-global--palette--white)' }}
+                  className={`${spacing.mlSm} pipeline-info-help-icon`}
                 >
-                  <QuestionCircle />
+                  <HelpIcon />
                 </Button>
               </Popover>
             </Title>
@@ -222,40 +210,25 @@ export const ReviewStep: React.FunctionComponent = () => {
         </>
       ) : null}
       <TextContent className={spacing.mbSm}>
-        <Title headingLevel="h3" size="xl">
+        <Title headingLevel="h3" size="lg">
           {cutoverPipelineName}
-
           <Popover
+            hasAutoWidth
             bodyContent={
-              isStatefulMigration ? (
-                <TextContent>
-                  <Text>
-                    This shows the pipeline tasks for a cutover import. During a cutover import:
-                  </Text>
-                  <List>
-                    <ListItem>All applications on the source namespace are halted.</ListItem>
-                    <ListItem>PVC data is migrated into the active project.</ListItem>
-                    <ListItem>Workloads are migrated into the active project.</ListItem>
-                  </List>
-                  {hasMultiplePipelines ? (
-                    <Text>The cutover pipeline is the final step in a migration project.</Text>
-                  ) : null}
-                </TextContent>
-              ) : (
-                <TextContent>
-                  <Text>This shows the pipeline tasks for the application import</Text>
-                </TextContent>
-              )
+              <PipelineExplanation
+                action="cutover"
+                isStatefulMigration={isStatefulMigration}
+                hasVisualization
+              />
             }
           >
             <Button
-              aria-label="More info for visualization pipeline field"
+              aria-label={`More info for ${cutoverPipelineName} pipeline visualization`}
               variant="link"
               isInline
-              className="pf-u-ml-sm"
-              style={{ color: 'var(--pf-global--palette--white)' }}
+              className={`${spacing.mlSm} pipeline-info-help-icon`}
             >
-              <QuestionCircle />
+              <HelpIcon />
             </Button>
           </Popover>
         </Title>

--- a/src/reused/pipelines-plugin/src/utils/pipeline-filter-reducer.ts
+++ b/src/reused/pipelines-plugin/src/utils/pipeline-filter-reducer.ts
@@ -5,6 +5,15 @@ import { Condition, PipelineRunKind } from '../types';
 // NOTE: This is only a partial snippet of the original file, all we needed was the `pipelineRunStatus` function.
 // NOTE: i18next usage has been temporarily removed here as we cannot inherit the strings from the console itself.
 
+// NOTE: This type has been added since copying the code:
+export type PipelineRunStatusString =
+  | 'Running'
+  | 'Succeeded'
+  | 'Failed'
+  | 'Cancelled'
+  | 'Pending'
+  | 'Skipped';
+
 export enum SucceedConditionReason {
   PipelineRunCancelled = 'PipelineRunCancelled',
   TaskRunCancelled = 'TaskRunCancelled',
@@ -20,7 +29,7 @@ export enum SucceedConditionReason {
 
 // Converts the PipelineRun (and TaskRun) condition status into a human readable string.
 // See also tkn cli implementation at https://github.com/tektoncd/cli/blob/release-v0.15.0/pkg/formatted/k8s.go#L54-L83
-export const pipelineRunStatus = (pipelineRun: PipelineRunKind): string | null => {
+export const pipelineRunStatus = (pipelineRun: PipelineRunKind): PipelineRunStatusString | null => {
   const conditions: Condition[] = _.get(pipelineRun, ['status', 'conditions'], []);
   if (conditions.length === 0) return null;
 


### PR DESCRIPTION
Resolves #98
Resolves #100

This PR takes the existing explanations of each pipeline from the Review step of the wizard and abstracts them into a `PipelineExplanation` component that is reused for these new confirmation modals. The explanation of a stage or cutover pipeline differs slightly based on whether it accompanies a visualization and whether there is one pipeline or two (whether PVCs are part of the project). See screenshots below. Some minor style bugs around the popovers on the Review step have also been fixed.

This also adds a confirmation dialog when clicking Delete in the kebab menu next to the Stage and Cutover buttons.

Additionally, this PR restricts usage of the Stage, Cutover and Delete actions in certain conditions:
* Stage or Cutover cannot be started while any PipelineRun in the group is still running
* Delete is not allowed while any PipelineRun in the group is still running
* Stage or Cutover cannot be started if a Cutover has already succeeded

See screenshots at the bottom for tooltip messages that appear in these cases.

# Screenshots

## Review step of wizard, stateful app migration (two pipelines, PVCs were selected)

Stage pipeline info button:
![Screen Shot 2022-07-19 at 12 09 47 PM](https://user-images.githubusercontent.com/811963/179798526-f20e9015-e117-4b60-b7a0-c5866bc3f814.png)

Cutover pipeline info button:
![Screen Shot 2022-07-19 at 12 09 51 PM](https://user-images.githubusercontent.com/811963/179798553-eab2df22-aac7-4ca1-a612-da71b56d874b.png)

## Review step of wizard, stateless app migration (one pipeline, no PVCs were selected)

Cutover pipeline info button:
![Screen Shot 2022-07-19 at 12 13 51 PM](https://user-images.githubusercontent.com/811963/179799021-8fab47eb-553f-4801-9e92-1ef3667e8545.png)

## Application Imports page, stateful app migration

Stage confirm modal:
![Screen Shot 2022-07-19 at 12 10 08 PM](https://user-images.githubusercontent.com/811963/179798605-133a1cfa-54b0-48b3-b287-376633cc045a.png)

Cutover confirm modal:
![Screen Shot 2022-07-19 at 12 10 21 PM](https://user-images.githubusercontent.com/811963/179798629-d7cf7444-c14b-47b7-89b1-34ff0a2351b2.png)

## Application Imports page, stateless app migration

Cutover confirm modal:
![Screen Shot 2022-07-19 at 12 14 00 PM](https://user-images.githubusercontent.com/811963/179799063-672927ea-dce1-4540-bf23-9cb0531ba4d0.png)

## Application Imports page, all migrations

Delete confirm modal:
![Screen Shot 2022-07-16 at 10 55 18 AM](https://user-images.githubusercontent.com/811963/179360130-966a2d8a-e8c9-4da6-a595-792e62f9c6f7.png)

Delete disabled tooltip:
![Screen Shot 2022-07-18 at 10 32 34 AM](https://user-images.githubusercontent.com/811963/179534832-4dfbb727-2d14-4b32-af8b-b9c93fed131a.png)

Stage/Cutover disabled tooltip due to a running pipeline:
![Screen Shot 2022-07-16 at 10 37 49 AM](https://user-images.githubusercontent.com/811963/179359852-7472d9d2-ba5f-4f83-9b6c-b7d8c53d4fc6.png)

## Application Imports page, stateful app migration

Stage/Cutover disabled tooltip due to cutover already succeeded:
![Screen Shot 2022-07-18 at 10 36 42 AM](https://user-images.githubusercontent.com/811963/179535695-112d5262-4f77-4c11-be52-a1c40cb5139b.png)

