### PR TITLE
Fix regression in wizard form state, simplify validation on first wizard step

### DIFF
--- a/src/components/ImportWizard/ImportWizardFormContext.tsx
+++ b/src/components/ImportWizard/ImportWizardFormContext.tsx
@@ -46,8 +46,18 @@ export const useImportWizardFormState = () => {
       return true;
     });
 
-  const apiUrlField = useFormField('', credentialsFieldSchema.label('Cluster API URL'));
-  const tokenField = useFormField('', credentialsFieldSchema.label('OAuth token'));
+  const resetSourceSelections = () => {
+    // If the source cluster/project is changing, reset everything the user has selected based on data from the source.
+    forms.pvcSelect.clear();
+    forms.pvcEdit.clear();
+  };
+
+  const apiUrlField = useFormField('', credentialsFieldSchema.label('Cluster API URL'), {
+    onChange: resetSourceSelections,
+  });
+  const tokenField = useFormField('', credentialsFieldSchema.label('OAuth token'), {
+    onChange: resetSourceSelections,
+  });
 
   const sourceApiRootQuery = useSourceApiRootQuery(sourceApiSecretField.value);
   const credentialsAreValid = areSourceCredentialsValid(
@@ -90,7 +100,9 @@ export const useImportWizardFormState = () => {
     editValuesByPVCField.reinitialize(defaultEditValuesByPVC);
   };
 
-  const sourceNamespaceField = useFormField('', yup.string()); // Temporary schema reassigned below
+  const sourceNamespaceField = useFormField('', yup.string(), {
+    onChange: resetSourceSelections,
+  }); // Temporary schema reassigned below
   const validateSourceNamespaceQuery = useValidateSourceNamespaceQuery(
     sourceApiSecretField.value,
     sourceNamespaceField.value,

--- a/src/components/ImportWizard/SourceClusterProjectStep.tsx
+++ b/src/components/ImportWizard/SourceClusterProjectStep.tsx
@@ -19,12 +19,12 @@ import {
   useSourceApiRootQuery,
   useValidateSourceNamespaceQuery,
 } from 'src/api/queries/sourceResources';
-import { areSourceCredentialsValid } from 'src/api/proxyHelpers';
 import { useNamespaceContext } from 'src/context/NamespaceContext';
 
 export const SourceClusterProjectStep: React.FunctionComponent = () => {
   const namespace = useNamespaceContext();
-  const form = React.useContext(ImportWizardFormContext).sourceClusterProject;
+  const formContext = React.useContext(ImportWizardFormContext);
+  const form = formContext.sourceClusterProject;
 
   const configureSourceSecretMutation = useConfigureSourceSecretMutation({
     existingSecretFromState: form.values.sourceApiSecret,
@@ -49,12 +49,6 @@ export const SourceClusterProjectStep: React.FunctionComponent = () => {
 
   const credentialsValidating =
     configureSourceSecretMutation.isLoading || sourceApiRootQuery.isLoading;
-  const credentialsAreValid = areSourceCredentialsValid(
-    form.fields.apiUrl,
-    form.fields.token,
-    form.fields.sourceApiSecret,
-    sourceApiRootQuery,
-  );
 
   const validateSourceNamespaceQuery = useValidateSourceNamespaceQuery(
     form.values.sourceApiSecret,
@@ -92,7 +86,7 @@ export const SourceClusterProjectStep: React.FunctionComponent = () => {
 
   const apiUrlFieldProps = getAsyncValidationFieldProps({
     validating: credentialsValidating,
-    valid: credentialsAreValid,
+    valid: form.fields.apiUrl.isValid,
     labelIcon: (
       <Popover
         headerContent={`API URL of the source cluster`}
@@ -118,7 +112,7 @@ export const SourceClusterProjectStep: React.FunctionComponent = () => {
 
   const sourceTokenFieldProps = getAsyncValidationFieldProps({
     validating: credentialsValidating,
-    valid: credentialsAreValid,
+    valid: form.fields.token.isValid,
     labelIcon: (
       <Popover
         headerContent={`OAuth token of the source cluster`}
@@ -144,7 +138,7 @@ export const SourceClusterProjectStep: React.FunctionComponent = () => {
 
   const sourceNamespaceFieldProps = getAsyncValidationFieldProps({
     validating: validateSourceNamespaceQuery.isLoading,
-    valid: validateSourceNamespaceQuery.data?.data.kind === 'Namespace',
+    valid: form.fields.sourceNamespace.isValid,
     labelIcon: (
       <Popover
         headerContent={`Name of the project to be imported`}


### PR DESCRIPTION
Fixes #104.

When any of the 3 fields on the first wizard step change (API URL, token, source namespace) any form selections that are based on data loaded from the source cluster are now automatically reset.

While fixing this I also noticed that the usage of `areSourceCredentialsValid` in that wizard step is redundant since we already call that within the schema validation of these fields in `ImportWizardFormContext`, so we can simply use the `isValid` properties of the fields instead.