### PR TITLE
Correctly refuse to show the namespaced pages if no namespace is selected

### DIFF
--- a/src/api/queries/pipelines.ts
+++ b/src/api/queries/pipelines.ts
@@ -61,12 +61,13 @@ export const useWatchPipelineRuns = () => {
 
 // TODO memoize these?
 export const useWatchCranePipelineGroups = () => {
+  const namespace = useNamespaceContext();
   const [watchedPipelines, pipelinesLoaded, pipelinesError] = useWatchPipelines();
   const [watchedPipelineRuns, pipelineRunsLoaded, pipelineRunsError] = useWatchPipelineRuns();
 
   // Pipeline tabs show up in creation order, PipelineRun history shows up latest first
-  const allPipelines = sortByCreationTimestamp(watchedPipelines, 'asc');
-  const allPipelineRuns = sortByStartedTime(watchedPipelineRuns, 'desc');
+  const allPipelines = namespace ? sortByCreationTimestamp(watchedPipelines, 'asc') : [];
+  const allPipelineRuns = namespace ? sortByStartedTime(watchedPipelineRuns, 'desc') : [];
 
   const byAction =
     (action: CraneAnnotations['crane-ui-plugin.konveyor.io/action']) =>

--- a/src/components/AppImportsPage.tsx
+++ b/src/components/AppImportsPage.tsx
@@ -79,6 +79,7 @@ const AppImportsPage: React.FunctionComponent<AppImportsPageProps> = ({
   // If pipeline groups are loaded and we don't have one selected, or we have one selected that doesn't exist, select the first one
   React.useEffect(() => {
     if (
+      !isAllNamespaces &&
       loaded &&
       pipelineGroups.length > 0 &&
       (!activePipelineGroupName ||
@@ -86,7 +87,13 @@ const AppImportsPage: React.FunctionComponent<AppImportsPageProps> = ({
     ) {
       setActivePipelineGroupName(pipelineGroups[0].name, 'replace');
     }
-  }, [activePipelineGroupName, loaded, pipelineGroups, setActivePipelineGroupName]);
+  }, [
+    isAllNamespaces,
+    loaded,
+    pipelineGroups,
+    activePipelineGroupName,
+    setActivePipelineGroupName,
+  ]);
 
   const areTabsVisible = pipelineGroups.length > 1;
   const activePipelineGroup = pipelineGroups.find(({ name }) => name === activePipelineGroupName);


### PR DESCRIPTION
Fixes #117.

When I was testing the "no project selected" screen, I didn't have any pipelines created in any namespace. It turns out that the `useWatchK8sResource` hooks we are using default to loading resources from all namespaces if the given namespace is undefined, so the "no project selected" screen was never reached since the page successfully loaded pipelines.

This PR ensures no pipelines can be loaded/selected until there is a defined namespace.