### PR TITLE
WIP: feat(image-sync): update pipelines for image

### DIFF
--- a/src/api/pipelineHelpers.ts
+++ b/src/api/pipelineHelpers.ts
@@ -124,6 +124,9 @@ export const formsToTektonResources = (
         tasks.generateSourceKubeconfigTask,
         tasks.generateDestinationKubeconfigTask,
         tasks.craneExportTask,
+        tasks.sourceRegistryInfo,
+        tasks.destinationRegistryInfo,
+        tasks.imageSyncTask,
         ...(isStatefulMigration
           ? [
               tasks.quiesceDeploymentsTask,


### PR DESCRIPTION
Implementes konveyor/enhancements#77 without introducing a whole new pipeline.

The idea here is that we can run the image-sync task without creating a whole new pipeline to worry about. If there are no imagestreams that need `skopeo sync`, the task just returns success. This could prevent us from having to implement logic for discovering ImageStreams.

Fixes #110
Fixes #111 

Screenshots:
![image](https://user-images.githubusercontent.com/569754/180516899-1a8d7053-b342-49f3-a43d-17506bf5e394.png)
![image](https://user-images.githubusercontent.com/569754/180516992-2fbe350b-bd85-40a6-afb1-3292069c664e.png)

![image](https://user-images.githubusercontent.com/569754/180516744-2c997784-c7a4-425b-8839-1442d45c0541.png)
