### PR TITLE
feat(pipelines): incorporate registry-info into pipelines

### DIFF
--- a/src/api/pipelineHelpers.ts
+++ b/src/api/pipelineHelpers.ts
@@ -124,6 +124,8 @@ export const formsToTektonResources = (
         tasks.generateSourceKubeconfigTask,
         tasks.generateDestinationKubeconfigTask,
         tasks.craneExportTask,
+        tasks.sourceRegistryInfo,
+        tasks.destinationRegistryInfo,
         ...(isStatefulMigration
           ? [
               tasks.quiesceDeploymentsTask,


### PR DESCRIPTION
1. Add (source|destination)-registry-info and image-sync to task
   helpers.
2. Update existing pipeline to leverage registry-info in transform task.

Fixes #111 