### PR TITLE
Convert summary tables to PF DescriptionList

### DIFF
--- a/src/components/AppImports/AppImports.css
+++ b/src/components/AppImports/AppImports.css
@@ -1,7 +1,0 @@
-.pf-m-grid.pf-c-table.summary-table tbody:first-of-type {
-  border-top: 0;
-}
-
-.pf-m-grid.pf-c-table.summary-table tr:last-child {
-  border-bottom: 0;
-}

--- a/src/components/AppImports/PipelineGroupSummary.tsx
+++ b/src/components/AppImports/PipelineGroupSummary.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import {
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+} from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 import { getPipelineGroupSourceNamespace } from 'src/api/pipelineHelpers';
@@ -19,59 +24,37 @@ export const PipelineGroupSummary: React.FunctionComponent<PipelineGroupSummaryP
   const namespace = useNamespaceContext();
   const latestPipelineRun = pipelineGroup.pipelineRuns.latestNonPending;
   return (
-    <TableComposable
-      aria-label="Pipeline import summary"
-      variant="compact"
-      borders={false}
-      gridBreakPoint="grid"
-      className={`summary-table ${spacing.mbLg}`}
+    <DescriptionList
+      isHorizontal
+      horizontalTermWidthModifier={{ default: '30ch' }}
+      className={`${spacing.mtXl} ${spacing.mb_2xl}`}
     >
-      <Thead>
-        <Tr>
-          <Th modifier="nowrap" id="source-project-heading">
-            Source project
-          </Th>
-          <Th modifier="nowrap" id="pvc-heading">
-            Persistent volume claims
-          </Th>
-          <Th modifier="nowrap" id="status-heading">
-            Last run status
-          </Th>
-        </Tr>
-      </Thead>
-      <Tbody>
-        <Tr className={spacing.pl_0}>
-          <Td
-            className="pf-m-truncate"
-            dataLabel="Source project"
-            aria-labelledby="source-project-heading"
-          >
-            {getPipelineGroupSourceNamespace(pipelineGroup)}
-          </Td>
-          <Td
-            className="pf-m-truncate"
-            dataLabel="Persistent volume claims"
-            aria-labelledby="pvc-heading"
-          >
-            {pipelineGroup.pipelines.stage?.spec.tasks.filter(
-              (task) => task.taskRef?.name === 'crane-transfer-pvc',
-            ).length || 0}
-          </Td>
-          <Td
-            className="pf-m-truncate"
-            dataLabel="Last run status"
-            aria-labelledby="status-heading"
-          >
-            {latestPipelineRun ? (
-              <Link to={pipelineRunUrl(namespace, latestPipelineRun)}>
-                <PipelineRunStatus pipelineRun={latestPipelineRun} showAction />
-              </Link>
-            ) : (
-              'Not started'
-            )}
-          </Td>
-        </Tr>
-      </Tbody>
-    </TableComposable>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Source project</DescriptionListTerm>
+        <DescriptionListDescription>
+          {getPipelineGroupSourceNamespace(pipelineGroup)}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Persistent volume claims</DescriptionListTerm>
+        <DescriptionListDescription>
+          {pipelineGroup.pipelines.stage?.spec.tasks.filter(
+            (task) => task.taskRef?.name === 'crane-transfer-pvc',
+          ).length || 0}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Last run status</DescriptionListTerm>
+        <DescriptionListDescription>
+          {latestPipelineRun ? (
+            <Link to={pipelineRunUrl(namespace, latestPipelineRun)}>
+              <PipelineRunStatus pipelineRun={latestPipelineRun} showAction />
+            </Link>
+          ) : (
+            'Not started'
+          )}
+        </DescriptionListDescription>
+      </DescriptionListGroup>
+    </DescriptionList>
   );
 };

--- a/src/components/AppImportsPage.tsx
+++ b/src/components/AppImportsPage.tsx
@@ -36,7 +36,6 @@ import { NamespaceContext, useNamespaceContext } from 'src/context/NamespaceCont
 import { PipelineGroupHeader } from './AppImports/PipelineGroupHeader';
 import { PipelineGroupSummary } from './AppImports/PipelineGroupSummary';
 import { PipelineGroupHistoryTable } from './AppImports/PipelineGroupHistoryTable';
-import './AppImports/AppImports.css';
 
 const queryClient = new QueryClient();
 

--- a/src/components/ImportWizard/ImportWizard.css
+++ b/src/components/ImportWizard/ImportWizard.css
@@ -2,10 +2,6 @@
   height: 100%;
 }
 
-#crane-import-wizard .project-details-table {
-  width: auto;
-}
-
 #crane-import-wizard .json-popover .pf-c-popover__content {
   overflow-y: scroll;
   max-height: 20rem;

--- a/src/components/ImportWizard/ReviewStep.tsx
+++ b/src/components/ImportWizard/ReviewStep.tsx
@@ -11,6 +11,10 @@ import {
   Button,
   Popover,
   Title,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
 } from '@patternfly/react-core';
 import { CodeEditor, Language } from '@patternfly/react-code-editor';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
@@ -72,114 +76,87 @@ export const ReviewStep: React.FunctionComponent = () => {
           that will be created when you select Finish.
         </Text>
       </TextContent>
-      <TableComposable
-        gridBreakPoint="grid"
-        aria-label="Application import review"
-        variant="compact"
-        borders={false}
-        className={spacing.mbLg}
+      <DescriptionList
+        isHorizontal
+        horizontalTermWidthModifier={{ default: '30ch' }}
+        className={`${spacing.mtLg} ${spacing.mbXl}`}
       >
-        <Thead>
-          <Tr>
-            <Th modifier="nowrap" id="pipeline-name">
-              Pipeline {hasMultiplePipelines ? 'names' : 'name'}
-            </Th>
-            <Th modifier="nowrap" id="source-cluster-api-url">
-              Source cluster API URL
-            </Th>
-            <Th modifier="nowrap" id="source-project-name">
-              Source project name
-            </Th>
-            <Th modifier="nowrap" id="persistent-volume-claims">
-              Persistent volume claims
-            </Th>
-          </Tr>
-        </Thead>
-        <Tbody>
-          <Tr>
-            <Td
-              className="pf-m-truncate"
-              aria-labelledby="pipeline-name"
-              dataLabel="Pipeline names"
-            >
-              {(hasMultiplePipelines
-                ? [stagePipelineName, cutoverPipelineName]
-                : [cutoverPipelineName]
-              ).join(', ')}
-            </Td>
-
-            <Td
-              className="pf-m-truncate"
-              aria-labelledby="source-cluster-api-url"
-              dataLabel="Source cluster API URL"
-            >
-              {forms.sourceClusterProject.values.apiUrl}
-            </Td>
-
-            <Td
-              className="pf-m-truncate"
-              aria-labelledby="source-project-name"
-              dataLabel="Source project name"
-            >
-              {forms.sourceClusterProject.values.sourceNamespace}
-            </Td>
-
-            <Td
-              className="pf-m-truncate"
-              aria-labelledby="persistent-volume-claims"
-              dataLabel="Persistent volume claims"
-            >
-              {forms.pvcSelect.values.selectedPVCs.length > 0 ? (
-                <Popover
-                  aria-label="Persistent volume claim details"
-                  headerContent="Persistent volume claims"
-                  hasAutoWidth
-                  bodyContent={
-                    <TableComposable variant="compact" borders={false}>
-                      <Thead>
-                        <Tr>
-                          <Th modifier="nowrap">{pvcColumnNames.sourcePvcName}</Th>
-                          <Th modifier="nowrap">{pvcColumnNames.targetPvcName}</Th>
-                          <Th modifier="nowrap">{pvcColumnNames.storageClass}</Th>
-                          <Th modifier="nowrap">{pvcColumnNames.capacity}</Th>
-                          <Th modifier="nowrap">{pvcColumnNames.verifyCopy}</Th>
-                        </Tr>
-                      </Thead>
-                      <Tbody>
-                        {forms.pvcSelect.values.selectedPVCs.map((pvc) => {
-                          const { targetPvcName, storageClass, capacity, verifyCopy } =
-                            forms.pvcEdit.values.editValuesByPVC[pvc.metadata?.name || ''];
-                          return (
-                            <Tr key={pvc.metadata?.name}>
-                              <Td dataLabel={pvcColumnNames.sourcePvcName}>{pvc.metadata?.name}</Td>
-                              <Td dataLabel={pvcColumnNames.targetPvcName}>{targetPvcName}</Td>
-                              <Td dataLabel={pvcColumnNames.storageClass}>{storageClass}</Td>
-                              <Td dataLabel={pvcColumnNames.capacity}>{capacity}</Td>
-                              <Td dataLabel={pvcColumnNames.verifyCopy}>
-                                {verifyCopy ? 'Yes' : 'No'}
-                              </Td>
-                            </Tr>
-                          );
-                        })}
-                      </Tbody>
-                    </TableComposable>
-                  }
+        <DescriptionListGroup>
+          <DescriptionListTerm>
+            Pipeline {hasMultiplePipelines ? 'names' : 'name'}
+          </DescriptionListTerm>
+          <DescriptionListDescription>
+            {(hasMultiplePipelines
+              ? [stagePipelineName, cutoverPipelineName]
+              : [cutoverPipelineName]
+            ).join(', ')}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Source cluster API URL</DescriptionListTerm>
+          <DescriptionListDescription>
+            {forms.sourceClusterProject.values.apiUrl}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Source project name</DescriptionListTerm>
+          <DescriptionListDescription>
+            {forms.sourceClusterProject.values.sourceNamespace}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Persistent volume claims</DescriptionListTerm>
+          <DescriptionListDescription>
+            {forms.pvcSelect.values.selectedPVCs.length > 0 ? (
+              <Popover
+                aria-label="Persistent volume claim details"
+                headerContent="Persistent volume claims"
+                hasAutoWidth
+                bodyContent={
+                  <TableComposable variant="compact" borders={false}>
+                    <Thead>
+                      <Tr>
+                        <Th modifier="nowrap">{pvcColumnNames.sourcePvcName}</Th>
+                        <Th modifier="nowrap">{pvcColumnNames.targetPvcName}</Th>
+                        <Th modifier="nowrap">{pvcColumnNames.storageClass}</Th>
+                        <Th modifier="nowrap">{pvcColumnNames.capacity}</Th>
+                        <Th modifier="nowrap">{pvcColumnNames.verifyCopy}</Th>
+                      </Tr>
+                    </Thead>
+                    <Tbody>
+                      {forms.pvcSelect.values.selectedPVCs.map((pvc) => {
+                        const { targetPvcName, storageClass, capacity, verifyCopy } =
+                          forms.pvcEdit.values.editValuesByPVC[pvc.metadata?.name || ''];
+                        return (
+                          <Tr key={pvc.metadata?.name}>
+                            <Td dataLabel={pvcColumnNames.sourcePvcName}>{pvc.metadata?.name}</Td>
+                            <Td dataLabel={pvcColumnNames.targetPvcName}>{targetPvcName}</Td>
+                            <Td dataLabel={pvcColumnNames.storageClass}>{storageClass}</Td>
+                            <Td dataLabel={pvcColumnNames.capacity}>{capacity}</Td>
+                            <Td dataLabel={pvcColumnNames.verifyCopy}>
+                              {verifyCopy ? 'Yes' : 'No'}
+                            </Td>
+                          </Tr>
+                        );
+                      })}
+                    </Tbody>
+                  </TableComposable>
+                }
+              >
+                <Button
+                  aria-label={`${forms.pvcSelect.values.selectedPVCs.length} persistent volume claims`}
+                  variant="link"
+                  isInline
                 >
-                  <Button
-                    aria-label={`${forms.pvcSelect.values.selectedPVCs.length} persistent volume claims`}
-                    variant="link"
-                    isInline
-                  >
-                    {forms.pvcSelect.values.selectedPVCs.length}
-                  </Button>
-                </Popover>
-              ) : (
-                0
-              )}
-            </Td>
-          </Tr>
-        </Tbody>
-      </TableComposable>
+                  {forms.pvcSelect.values.selectedPVCs.length}
+                </Button>
+              </Popover>
+            ) : (
+              0
+            )}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      </DescriptionList>
       {hasMultiplePipelines ? (
         <>
           <TextContent className={spacing.mbSm}>

--- a/src/components/ImportWizard/SourceProjectDetailsStep.tsx
+++ b/src/components/ImportWizard/SourceProjectDetailsStep.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
-import { TextContent, Text } from '@patternfly/react-core';
-import { TableComposable, Tbody, Td, Th, Tr } from '@patternfly/react-table';
+import {
+  TextContent,
+  Text,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+} from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 import { ImportWizardFormContext } from './ImportWizardFormContext';
@@ -30,26 +36,26 @@ export const SourceProjectDetailsStep: React.FunctionComponent = () => {
         <Text component="h2">Project details</Text>
         <Text component="h3">{forms.sourceClusterProject.values.sourceNamespace}</Text>
       </TextContent>
-      <TableComposable
-        aria-label="Project details table"
-        variant="compact"
-        className="project-details-table"
-      >
-        <Tbody>
-          <Tr>
-            <Th className={spacing.pr_2xl}>Pods</Th>
-            <Td id="details-pods">{sourcePodsQuery.data?.data.items.length}</Td>
-          </Tr>
-          <Tr>
-            <Th className={spacing.pr_2xl}>Persistent Volume Claims (PVCs)</Th>
-            <Td id="details-pvcs">{sourcePVCsQuery.data?.data.items.length}</Td>
-          </Tr>
-          <Tr>
-            <Th className={spacing.pr_2xl}>Services</Th>
-            <Td id="details-services">{sourceServicesQuery.data?.data.items.length}</Td>
-          </Tr>
-        </Tbody>
-      </TableComposable>
+      <DescriptionList isHorizontal horizontalTermWidthModifier={{ default: '30ch' }}>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Pods</DescriptionListTerm>
+          <DescriptionListDescription>
+            {sourcePodsQuery.data?.data.items.length}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Persistent Volume Claims (PVCs)</DescriptionListTerm>
+          <DescriptionListDescription>
+            {sourcePVCsQuery.data?.data.items.length}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Services</DescriptionListTerm>
+          <DescriptionListDescription>
+            {sourceServicesQuery.data?.data.items.length}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      </DescriptionList>
     </ResolvedQueries>
   );
 };


### PR DESCRIPTION
Resolves #57.

Our UI has three term/description summaries:
* In the wizard on the Project Details step, summarizing your selected project
* In the wizard on the Review step, summarizing your inputs and the pipelines
* On the imports page, summarizing the pipeline group and its status

Currently we use tables for these, with some inconsistent CSS hacks to make them look closer to the designs and with questionable accessibility. The PatternFly DescriptionList component looks much closer to the original design, is more semantically correct, and is simpler in structure. Now that PF fixed a layout bug with it that we needed, we can use it.

This PR converts the above 3 summaries to use DescriptionList.

# Screenshots

## Project details - Before
![Screen Shot 2022-07-26 at 12 11 52 PM](https://user-images.githubusercontent.com/811963/181057329-ea114e7d-f7e8-41c6-b4c4-d8b1cf972b8d.png)

## Project details - After
![Screen Shot 2022-07-26 at 11 44 19 AM](https://user-images.githubusercontent.com/811963/181056851-76a01d7a-1528-4359-9128-7026b06ed8e4.png)

## Review - Before
![Screen Shot 2022-07-26 at 12 12 27 PM](https://user-images.githubusercontent.com/811963/181057353-8953a14a-3924-47d9-8060-be751c7ba287.png)

## Review - After
![Screen Shot 2022-07-26 at 11 54 41 AM](https://user-images.githubusercontent.com/811963/181056878-56e5f2ac-7edc-4f9e-9428-568525320edc.png)

## Imports - Before
![Screen Shot 2022-07-26 at 12 12 37 PM](https://user-images.githubusercontent.com/811963/181057410-8668dbfc-c4f4-44f2-b7bb-f70a11b04a35.png)

## Imports - After
![Screen Shot 2022-07-26 at 12 02 07 PM](https://user-images.githubusercontent.com/811963/181056886-6b16d647-3522-45ac-a5ee-88ee1c88d9d9.png)

