### PR TITLE
feat(image-sync): add task to cutover pipeline

### DIFF
--- a/src/api/pipelineHelpers.ts
+++ b/src/api/pipelineHelpers.ts
@@ -143,6 +143,7 @@ export const formsToTektonResources = (
               })),
             ]
           : []),
+        tasks.imageSyncTask,
         tasks.craneTransformTask,
         tasks.craneApplyTask,
         tasks.kustomizeInitTask,

--- a/src/api/pipelineTaskHelpers.ts
+++ b/src/api/pipelineTaskHelpers.ts
@@ -80,12 +80,14 @@ export const getAllPipelineTasks = (forms: ImportWizardFormState, namespace: str
         value: '$(tasks.source-registry-info.results.internal)',
       },
       { name: 'src-public-registry-url', value: '$(tasks.source-registry-info.results.public)' },
+      { name: 'src-tls-verify', value: 'false' },
       { name: 'dest-context', value: 'destination' },
       { name: 'dest-namespace', value: '$(context.taskRun.namespace)' },
       {
         name: 'dest-public-registry-url',
         value: '$(tasks.destination-registry-info.results.public)',
       },
+      { name: 'dest-tls-verify', value: 'false' },
     ],
     taskRef: { name: 'crane-image-sync', kind: 'ClusterTask' },
     workspaces: [
@@ -97,13 +99,15 @@ export const getAllPipelineTasks = (forms: ImportWizardFormState, namespace: str
 
   const craneTransformTask: PipelineTask = {
     name: 'transform',
-    runAfter: ['source-registry-info', 'destination-registry-info'],
+    runAfter: ['image-sync'],
     params: [
       {
         name: 'optional-flags',
-        value: `"registry-replacement=${registryReplacements.join(
-          ',',
-        )}","pvc-rename-map=${selectedPVCs.map(pvcRenameMap).join(',')}"`,
+        value: JSON.stringify({
+          'registry-replacement': registryReplacements.join(','),
+          'pvc-rename-map': selectedPVCs.map(pvcRenameMap).join(','),
+          'src-internal-registry': '$(tasks.source-registry-info.results.internal)',
+        }),
       },
     ],
     taskRef: { name: 'crane-transform', kind: 'ClusterTask' },


### PR DESCRIPTION
Also sets `(src|dest)-tls-verify=false` on the image-sync task and
forces transform to runAfter image-sync.

Fixes #110 - Instead of creating a whole new pipeline, we are going to handle image transfer with a task in cutover pipeline that handles !http and https with self-signed certs registries.