### PR TITLE
Validate that namespace from URL exists before rendering any content

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -3,7 +3,7 @@
     "type": "console.page/route",
     "properties": {
       "exact": true,
-      "path": ["/app-imports/new/ns/:namespace"],
+      "path": ["/app-imports/new/ns/:namespace", "/app-imports/new/all-namespaces"],
       "component": { "$codeRef": "ImportPage" }
     }
   },

--- a/src/api/queries/namespaces.ts
+++ b/src/api/queries/namespaces.ts
@@ -1,0 +1,17 @@
+import { k8sGet, K8sGroupVersionKind, useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
+import { useQuery } from 'react-query';
+
+export const namespaceGVK: K8sGroupVersionKind = {
+  group: '',
+  version: 'v1',
+  kind: 'Namespace',
+};
+
+export const useHostNamespaceQuery = (namespace?: string) => {
+  const [model] = useK8sModel(namespaceGVK);
+  return useQuery(['namespace', namespace], {
+    queryFn: () => k8sGet({ model, name: namespace }),
+    enabled: !!namespace,
+    retry: false,
+  });
+};

--- a/src/api/queries/pipelines.ts
+++ b/src/api/queries/pipelines.ts
@@ -10,7 +10,6 @@ import {
 import { K8sModel } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
 import { useMutation, UseMutationOptions } from 'react-query';
 import { attachOwnerReference, getObjectRef, sortByCreationTimestamp } from 'src/utils/helpers';
-import { useNamespaceContext } from 'src/context/NamespaceContext';
 import { sortByStartedTime, WizardTektonResources } from '../pipelineHelpers';
 import { OAuthSecret } from '../types/Secret';
 import { secretGVK } from './secrets';
@@ -26,6 +25,7 @@ import {
   pipelineRunStatus,
   PipelineRunStatusString,
 } from 'src/reused/pipelines-plugin/src/utils/pipeline-filter-reducer';
+import { useValidatedNamespace } from 'src/common/hooks/useValidatedNamespace';
 
 export const pipelineGVK: K8sGroupVersionKind = {
   group: 'tekton.dev',
@@ -40,7 +40,7 @@ export const pipelineRunGVK: K8sGroupVersionKind = {
 };
 
 export const useWatchPipelines = () => {
-  const { namespace } = useNamespaceContext();
+  const { namespace } = useValidatedNamespace();
   return useK8sWatchResource<CranePipeline[]>({
     groupVersionKind: pipelineGVK,
     isList: true,
@@ -50,7 +50,7 @@ export const useWatchPipelines = () => {
 };
 
 export const useWatchPipelineRuns = () => {
-  const { namespace } = useNamespaceContext();
+  const { namespace } = useValidatedNamespace();
   return useK8sWatchResource<CranePipelineRun[]>({
     groupVersionKind: pipelineRunGVK,
     isList: true,
@@ -61,7 +61,7 @@ export const useWatchPipelineRuns = () => {
 
 // TODO memoize these?
 export const useWatchCranePipelineGroups = () => {
-  const { namespace } = useNamespaceContext();
+  const { namespace } = useValidatedNamespace();
   const [watchedPipelines, pipelinesLoaded, pipelinesError] = useWatchPipelines();
   const [watchedPipelineRuns, pipelineRunsLoaded, pipelineRunsError] = useWatchPipelineRuns();
 

--- a/src/api/queries/pipelines.ts
+++ b/src/api/queries/pipelines.ts
@@ -40,7 +40,7 @@ export const pipelineRunGVK: K8sGroupVersionKind = {
 };
 
 export const useWatchPipelines = () => {
-  const namespace = useNamespaceContext();
+  const { namespace } = useNamespaceContext();
   return useK8sWatchResource<CranePipeline[]>({
     groupVersionKind: pipelineGVK,
     isList: true,
@@ -50,7 +50,7 @@ export const useWatchPipelines = () => {
 };
 
 export const useWatchPipelineRuns = () => {
-  const namespace = useNamespaceContext();
+  const { namespace } = useNamespaceContext();
   return useK8sWatchResource<CranePipelineRun[]>({
     groupVersionKind: pipelineRunGVK,
     isList: true,
@@ -61,7 +61,7 @@ export const useWatchPipelineRuns = () => {
 
 // TODO memoize these?
 export const useWatchCranePipelineGroups = () => {
-  const namespace = useNamespaceContext();
+  const { namespace } = useNamespaceContext();
   const [watchedPipelines, pipelinesLoaded, pipelinesError] = useWatchPipelines();
   const [watchedPipelineRuns, pipelineRunsLoaded, pipelineRunsError] = useWatchPipelineRuns();
 

--- a/src/api/queries/pvcs.ts
+++ b/src/api/queries/pvcs.ts
@@ -1,5 +1,5 @@
 import { K8sGroupVersionKind, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import { useNamespaceContext } from 'src/context/NamespaceContext';
+import { useValidatedNamespace } from 'src/common/hooks/useValidatedNamespace';
 import { PersistentVolumeClaim } from '../types/PersistentVolume';
 
 export const pvcGVK: K8sGroupVersionKind = {
@@ -9,7 +9,7 @@ export const pvcGVK: K8sGroupVersionKind = {
 };
 
 export const useWatchPVCs = () => {
-  const { namespace } = useNamespaceContext();
+  const { namespace } = useValidatedNamespace();
   const [data, loaded, error] = useK8sWatchResource<PersistentVolumeClaim[]>({
     groupVersionKind: pvcGVK,
     isList: true,

--- a/src/api/queries/pvcs.ts
+++ b/src/api/queries/pvcs.ts
@@ -9,7 +9,7 @@ export const pvcGVK: K8sGroupVersionKind = {
 };
 
 export const useWatchPVCs = () => {
-  const namespace = useNamespaceContext();
+  const { namespace } = useNamespaceContext();
   const [data, loaded, error] = useK8sWatchResource<PersistentVolumeClaim[]>({
     groupVersionKind: pvcGVK,
     isList: true,

--- a/src/api/queries/secrets.ts
+++ b/src/api/queries/secrets.ts
@@ -9,7 +9,7 @@ import {
 import { K8sModel } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
 import { useMutation } from 'react-query';
 import { SECRET_SERVICE_URL } from 'src/common/constants';
-import { useNamespaceContext } from 'src/context/NamespaceContext';
+import { useValidatedNamespace } from 'src/common/hooks/useValidatedNamespace';
 import { OAuthSecret, Secret } from '../types/Secret';
 
 export const secretGVK: K8sGroupVersionKind = { group: '', version: 'v1', kind: 'Secret' };
@@ -28,7 +28,7 @@ export const useConfigureSourceSecretMutation = ({
   onSuccess,
 }: UseConfigureSecretMutationArgs) => {
   const [secretModel] = useK8sModel(secretGVK);
-  const { namespace } = useNamespaceContext();
+  const { namespace } = useValidatedNamespace();
   return useMutation<OAuthSecret, Error, ConfigureSourceSecretMutationParams>(
     async ({ apiUrl, token }) => {
       // If we already have a secret in state, use that instead of looking for one to replace.
@@ -62,7 +62,7 @@ export const useConfigureDestinationSecretMutation = ({
   onSuccess,
 }: UseConfigureSecretMutationArgs) => {
   const [secretModel] = useK8sModel(secretGVK);
-  const { namespace } = useNamespaceContext();
+  const { namespace } = useValidatedNamespace();
   const apiUrl = 'https://kubernetes.default.svc';
   return useMutation<OAuthSecret, Error>(
     async () => {

--- a/src/api/queries/secrets.ts
+++ b/src/api/queries/secrets.ts
@@ -28,7 +28,7 @@ export const useConfigureSourceSecretMutation = ({
   onSuccess,
 }: UseConfigureSecretMutationArgs) => {
   const [secretModel] = useK8sModel(secretGVK);
-  const namespace = useNamespaceContext();
+  const { namespace } = useNamespaceContext();
   return useMutation<OAuthSecret, Error, ConfigureSourceSecretMutationParams>(
     async ({ apiUrl, token }) => {
       // If we already have a secret in state, use that instead of looking for one to replace.
@@ -62,7 +62,7 @@ export const useConfigureDestinationSecretMutation = ({
   onSuccess,
 }: UseConfigureSecretMutationArgs) => {
   const [secretModel] = useK8sModel(secretGVK);
-  const namespace = useNamespaceContext();
+  const { namespace } = useNamespaceContext();
   const apiUrl = 'https://kubernetes.default.svc';
   return useMutation<OAuthSecret, Error>(
     async () => {

--- a/src/common/components/LoadingEmptyState.tsx
+++ b/src/common/components/LoadingEmptyState.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { EmptyState, EmptyStateIcon, Spinner, Title } from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+
+export const LoadingEmptyState: React.FunctionComponent = () => (
+  <EmptyState className={spacing.mtXl}>
+    <EmptyStateIcon variant="container" component={Spinner} />
+    <Title size="lg" headingLevel="h4">
+      Loading
+    </Title>
+  </EmptyState>
+);

--- a/src/common/components/NoProjectEmptyState.tsx
+++ b/src/common/components/NoProjectEmptyState.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { EmptyState, Title, EmptyStateBody } from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { Link } from 'react-router-dom';
+
+interface NoProjectEmptyStateProps {
+  selectProjectHref: string;
+}
+
+export const NoProjectEmptyState: React.FunctionComponent<NoProjectEmptyStateProps> = ({
+  selectProjectHref,
+}) => (
+  <EmptyState variant="large" className={spacing.mtXl}>
+    <Title headingLevel="h4" size="lg">
+      No project selected
+    </Title>
+    <EmptyStateBody>
+      <Link to={selectProjectHref}>Select a project</Link> and return to this page.
+    </EmptyStateBody>
+  </EmptyState>
+);

--- a/src/common/hooks/useValidatedNamespace.ts
+++ b/src/common/hooks/useValidatedNamespace.ts
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { useHistory } from 'react-router';
+import { useRouteMatch, useHistory } from 'react-router-dom';
 import { useHostNamespaceQuery } from 'src/api/queries/namespaces';
 
-const NamespaceContext = React.createContext<string>('');
-export const NamespaceContextProvider = NamespaceContext.Provider;
-export const useNamespaceContext = () => {
-  const namespace = React.useContext(NamespaceContext);
+export const useValidatedNamespace = () => {
+  const {
+    params: { namespace },
+  } = useRouteMatch<{ namespace: string }>();
   const validateQuery = useHostNamespaceQuery(namespace);
   return {
     namespace,
@@ -16,7 +16,7 @@ export const useNamespaceContext = () => {
 };
 
 export const useRedirectOnInvalidNamespaceEffect = (href: string) => {
-  const { isValidatingNamespace, isNamespaceValid, isAllNamespaces } = useNamespaceContext();
+  const { isValidatingNamespace, isNamespaceValid, isAllNamespaces } = useValidatedNamespace();
   const history = useHistory();
   React.useEffect(() => {
     if (!isValidatingNamespace && !isNamespaceValid && !isAllNamespaces) {

--- a/src/components/AppImports/PipelineGroupHistoryTable.tsx
+++ b/src/components/AppImports/PipelineGroupHistoryTable.tsx
@@ -5,8 +5,8 @@ import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-tab
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { Timestamp } from '@openshift-console/dynamic-plugin-sdk';
 
+import { useValidatedNamespace } from 'src/common/hooks/useValidatedNamespace';
 import { CranePipelineGroup } from 'src/api/types/CranePipeline';
-import { useNamespaceContext } from 'src/context/NamespaceContext';
 import { resourceActionToString } from 'src/api/pipelineHelpers';
 import { pipelineRunUrl } from 'src/utils/paths';
 import { PipelineRunStatus } from './PipelineRunStatus';
@@ -18,7 +18,7 @@ interface PipelineGroupHistoryTableProps {
 export const PipelineGroupHistoryTable: React.FunctionComponent<PipelineGroupHistoryTableProps> = ({
   pipelineGroup,
 }) => {
-  const { namespace } = useNamespaceContext();
+  const { namespace } = useValidatedNamespace();
   return (
     <>
       <Title headingLevel="h3" className={spacing.mbMd}>

--- a/src/components/AppImports/PipelineGroupHistoryTable.tsx
+++ b/src/components/AppImports/PipelineGroupHistoryTable.tsx
@@ -18,7 +18,7 @@ interface PipelineGroupHistoryTableProps {
 export const PipelineGroupHistoryTable: React.FunctionComponent<PipelineGroupHistoryTableProps> = ({
   pipelineGroup,
 }) => {
-  const namespace = useNamespaceContext();
+  const { namespace } = useNamespaceContext();
   return (
     <>
       <Title headingLevel="h3" className={spacing.mbMd}>

--- a/src/components/AppImports/PipelineGroupKebabMenu.tsx
+++ b/src/components/AppImports/PipelineGroupKebabMenu.tsx
@@ -4,9 +4,9 @@ import { Dropdown, KebabToggle, DropdownItem, Tooltip } from '@patternfly/react-
 
 import { CranePipelineGroup } from 'src/api/types/CranePipeline';
 import { isSomePipelineRunning, useDeletePipelineMutation } from 'src/api/queries/pipelines';
-import { useNamespaceContext } from 'src/context/NamespaceContext';
 import { pipelinesListUrl } from 'src/utils/paths';
 import { ConfirmModal } from 'src/common/components/ConfirmModal';
+import { useValidatedNamespace } from 'src/common/hooks/useValidatedNamespace';
 
 interface PipelineGroupKebabMenuProps {
   pipelineGroup: CranePipelineGroup;
@@ -17,7 +17,7 @@ export const PipelineGroupKebabMenu: React.FunctionComponent<PipelineGroupKebabM
   pipelineGroup,
   deletePipelineMutation,
 }) => {
-  const { namespace } = useNamespaceContext();
+  const { namespace } = useValidatedNamespace();
   const history = useHistory();
 
   const onFocus = (id: string) => {

--- a/src/components/AppImports/PipelineGroupKebabMenu.tsx
+++ b/src/components/AppImports/PipelineGroupKebabMenu.tsx
@@ -17,7 +17,7 @@ export const PipelineGroupKebabMenu: React.FunctionComponent<PipelineGroupKebabM
   pipelineGroup,
   deletePipelineMutation,
 }) => {
-  const namespace = useNamespaceContext();
+  const { namespace } = useNamespaceContext();
   const history = useHistory();
 
   const onFocus = (id: string) => {

--- a/src/components/AppImports/PipelineGroupSummary.tsx
+++ b/src/components/AppImports/PipelineGroupSummary.tsx
@@ -10,9 +10,9 @@ import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 import { getPipelineGroupSourceNamespace } from 'src/api/pipelineHelpers';
 import { CranePipelineGroup } from 'src/api/types/CranePipeline';
-import { useNamespaceContext } from 'src/context/NamespaceContext';
 import { pipelineRunUrl } from 'src/utils/paths';
 import { PipelineRunStatus } from './PipelineRunStatus';
+import { useValidatedNamespace } from 'src/common/hooks/useValidatedNamespace';
 
 interface PipelineGroupSummaryProps {
   pipelineGroup: CranePipelineGroup;
@@ -21,7 +21,7 @@ interface PipelineGroupSummaryProps {
 export const PipelineGroupSummary: React.FunctionComponent<PipelineGroupSummaryProps> = ({
   pipelineGroup,
 }) => {
-  const { namespace } = useNamespaceContext();
+  const { namespace } = useValidatedNamespace();
   const latestPipelineRun = pipelineGroup.pipelineRuns.latestNonPending;
   return (
     <DescriptionList

--- a/src/components/AppImports/PipelineGroupSummary.tsx
+++ b/src/components/AppImports/PipelineGroupSummary.tsx
@@ -21,7 +21,7 @@ interface PipelineGroupSummaryProps {
 export const PipelineGroupSummary: React.FunctionComponent<PipelineGroupSummaryProps> = ({
   pipelineGroup,
 }) => {
-  const namespace = useNamespaceContext();
+  const { namespace } = useNamespaceContext();
   const latestPipelineRun = pipelineGroup.pipelineRuns.latestNonPending;
   return (
     <DescriptionList

--- a/src/components/AppImportsPage.tsx
+++ b/src/components/AppImportsPage.tsx
@@ -34,33 +34,30 @@ import {
   appImportWizardUrl,
   projectDetailsAllNamespacesUrl,
 } from 'src/utils/paths';
-import {
-  NamespaceContextProvider,
-  useNamespaceContext,
-  useRedirectOnInvalidNamespaceEffect,
-} from 'src/context/NamespaceContext';
 
 import { PipelineGroupHeader } from './AppImports/PipelineGroupHeader';
 import { PipelineGroupSummary } from './AppImports/PipelineGroupSummary';
 import { PipelineGroupHistoryTable } from './AppImports/PipelineGroupHistoryTable';
 import { NoProjectEmptyState } from 'src/common/components/NoProjectEmptyState';
 import { LoadingEmptyState } from 'src/common/components/LoadingEmptyState';
+import {
+  useValidatedNamespace,
+  useRedirectOnInvalidNamespaceEffect,
+} from 'src/common/hooks/useValidatedNamespace';
 
 const queryClient = new QueryClient();
 
 const AppImportsPageWrapper: React.FunctionComponent = () => {
   const {
-    params: { pipelineGroupName: activePipelineGroupName, namespace },
-  } = useRouteMatch<{ pipelineGroupName: string; namespace: string }>();
+    params: { pipelineGroupName: activePipelineGroupName },
+  } = useRouteMatch<{ pipelineGroupName: string }>();
   return (
     <>
       <Helmet>
         <title>Application Imports</title>
       </Helmet>
       <QueryClientProvider client={queryClient}>
-        <NamespaceContextProvider value={namespace}>
-          <AppImportsPage activePipelineGroupName={activePipelineGroupName} />
-        </NamespaceContextProvider>
+        <AppImportsPage activePipelineGroupName={activePipelineGroupName} />
       </QueryClientProvider>
     </>
   );
@@ -75,7 +72,7 @@ const AppImportsPage: React.FunctionComponent<AppImportsPageProps> = ({
 }) => {
   const history = useHistory();
   const { pipelineGroups, loaded: pipelineGroupsLoaded, error } = useWatchCranePipelineGroups();
-  const { namespace, isValidatingNamespace, isAllNamespaces } = useNamespaceContext();
+  const { namespace, isValidatingNamespace, isAllNamespaces } = useValidatedNamespace();
   useRedirectOnInvalidNamespaceEffect(appImportsAllNamespacesUrl);
 
   const isLoaded = pipelineGroupsLoaded && !isValidatingNamespace;

--- a/src/components/ImportPage.tsx
+++ b/src/components/ImportPage.tsx
@@ -1,36 +1,25 @@
 import * as React from 'react';
 import Helmet from 'react-helmet';
-import { useRouteMatch } from 'react-router-dom';
 import { PageSection, Title } from '@patternfly/react-core';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ImportWizard } from './ImportWizard/ImportWizard';
-import { NamespaceContextProvider } from 'src/context/NamespaceContext';
 
 const queryClient = new QueryClient();
 
-const ImportPage: React.FunctionComponent = () => {
-  const {
-    params: { namespace },
-  } = useRouteMatch<{ namespace: string }>();
-  return (
-    <>
-      <Helmet>
-        <title>Crane</title>
-      </Helmet>
-      <QueryClientProvider client={queryClient}>
-        <NamespaceContextProvider value={namespace}>
-          <>
-            <PageSection variant="light">
-              <Title headingLevel="h1">Import application</Title>
-            </PageSection>
-            <PageSection variant="light" type="wizard">
-              <ImportWizard />
-            </PageSection>
-          </>
-        </NamespaceContextProvider>
-      </QueryClientProvider>
-    </>
-  );
-};
+const ImportPage: React.FunctionComponent = () => (
+  <>
+    <Helmet>
+      <title>Crane</title>
+    </Helmet>
+    <QueryClientProvider client={queryClient}>
+      <PageSection variant="light">
+        <Title headingLevel="h1">Import application</Title>
+      </PageSection>
+      <PageSection variant="light" type="wizard">
+        <ImportWizard />
+      </PageSection>
+    </QueryClientProvider>
+  </>
+);
 
 export default ImportPage;

--- a/src/components/ImportPage.tsx
+++ b/src/components/ImportPage.tsx
@@ -4,7 +4,7 @@ import { useRouteMatch } from 'react-router-dom';
 import { PageSection, Title } from '@patternfly/react-core';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ImportWizard } from './ImportWizard/ImportWizard';
-import { NamespaceContext } from 'src/context/NamespaceContext';
+import { NamespaceContextProvider } from 'src/context/NamespaceContext';
 
 const queryClient = new QueryClient();
 
@@ -18,7 +18,7 @@ const ImportPage: React.FunctionComponent = () => {
         <title>Crane</title>
       </Helmet>
       <QueryClientProvider client={queryClient}>
-        <NamespaceContext.Provider value={namespace}>
+        <NamespaceContextProvider value={namespace}>
           <>
             <PageSection variant="light">
               <Title headingLevel="h1">Import application</Title>
@@ -27,7 +27,7 @@ const ImportPage: React.FunctionComponent = () => {
               <ImportWizard />
             </PageSection>
           </>
-        </NamespaceContext.Provider>
+        </NamespaceContextProvider>
       </QueryClientProvider>
     </>
   );

--- a/src/components/ImportWizard/ImportWizard.tsx
+++ b/src/components/ImportWizard/ImportWizard.tsx
@@ -12,10 +12,6 @@ import wizardStyles from '@patternfly/react-styles/css/components/Wizard/wizard'
 import { IFormState, ResolvedQueries } from '@konveyor/lib-ui';
 import { useHistory } from 'react-router-dom';
 
-import {
-  useNamespaceContext,
-  useRedirectOnInvalidNamespaceEffect,
-} from 'src/context/NamespaceContext';
 import { SourceClusterProjectStep } from './SourceClusterProjectStep';
 import { SourceProjectDetailsStep } from './SourceProjectDetailsStep';
 import { PVCSelectStep } from './PVCSelectStep';
@@ -44,6 +40,10 @@ import {
 import { ImportWizardWelcomeModal } from './ImportWizardWelcomeModal';
 import { NoProjectEmptyState } from 'src/common/components/NoProjectEmptyState';
 import { LoadingEmptyState } from 'src/common/components/LoadingEmptyState';
+import {
+  useValidatedNamespace,
+  useRedirectOnInvalidNamespaceEffect,
+} from 'src/common/hooks/useValidatedNamespace';
 
 enum StepId {
   SourceClusterProject = 0,
@@ -96,7 +96,7 @@ export const ImportWizard: React.FunctionComponent = () => {
     !allNavDisabled && stepId >= 0 && stepIdReached >= stepId;
 
   const { namespace, isValidatingNamespace, isAllNamespaces, isNamespaceValid } =
-    useNamespaceContext();
+    useValidatedNamespace();
   useRedirectOnInvalidNamespaceEffect(appImportWizardAllNamespacesUrl);
 
   const configureDestinationSecretMutation = useConfigureDestinationSecretMutation({

--- a/src/components/ImportWizard/ImportWizardWelcomeModal.tsx
+++ b/src/components/ImportWizard/ImportWizardWelcomeModal.tsx
@@ -3,11 +3,11 @@ import { Link } from 'react-router-dom';
 import { Button, Modal, TextContent, Text, Checkbox } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { appImportsPageUrl, pipelinesListUrl } from 'src/utils/paths';
-import { useNamespaceContext } from 'src/context/NamespaceContext';
 import { useLocalStorage } from 'src/common/hooks/useLocalStorage';
+import { useValidatedNamespace } from 'src/common/hooks/useValidatedNamespace';
 
 export const ImportWizardWelcomeModal: React.FunctionComponent = () => {
-  const { namespace } = useNamespaceContext();
+  const { namespace } = useValidatedNamespace();
   const [isDisabled, setIsDisabled] = useLocalStorage('isCraneWizardWelcomeModalDisabled');
   const [isOpen, setIsOpen] = React.useState(isDisabled !== 'true');
   const onClose = () => setIsOpen(false);

--- a/src/components/ImportWizard/ImportWizardWelcomeModal.tsx
+++ b/src/components/ImportWizard/ImportWizardWelcomeModal.tsx
@@ -7,7 +7,7 @@ import { useNamespaceContext } from 'src/context/NamespaceContext';
 import { useLocalStorage } from 'src/common/hooks/useLocalStorage';
 
 export const ImportWizardWelcomeModal: React.FunctionComponent = () => {
-  const namespace = useNamespaceContext();
+  const { namespace } = useNamespaceContext();
   const [isDisabled, setIsDisabled] = useLocalStorage('isCraneWizardWelcomeModalDisabled');
   const [isOpen, setIsOpen] = React.useState(isDisabled !== 'true');
   const onClose = () => setIsOpen(false);

--- a/src/components/ImportWizard/SourceClusterProjectStep.tsx
+++ b/src/components/ImportWizard/SourceClusterProjectStep.tsx
@@ -19,10 +19,10 @@ import {
   useSourceApiRootQuery,
   useValidateSourceNamespaceQuery,
 } from 'src/api/queries/sourceResources';
-import { useNamespaceContext } from 'src/context/NamespaceContext';
+import { useValidatedNamespace } from 'src/common/hooks/useValidatedNamespace';
 
 export const SourceClusterProjectStep: React.FunctionComponent = () => {
-  const { namespace } = useNamespaceContext();
+  const { namespace } = useValidatedNamespace();
   const formContext = React.useContext(ImportWizardFormContext);
   const form = formContext.sourceClusterProject;
 

--- a/src/components/ImportWizard/SourceClusterProjectStep.tsx
+++ b/src/components/ImportWizard/SourceClusterProjectStep.tsx
@@ -22,7 +22,7 @@ import {
 import { useNamespaceContext } from 'src/context/NamespaceContext';
 
 export const SourceClusterProjectStep: React.FunctionComponent = () => {
-  const namespace = useNamespaceContext();
+  const { namespace } = useNamespaceContext();
   const formContext = React.useContext(ImportWizardFormContext);
   const form = formContext.sourceClusterProject;
 

--- a/src/context/NamespaceContext.tsx
+++ b/src/context/NamespaceContext.tsx
@@ -1,6 +1,26 @@
 import * as React from 'react';
+import { useHistory } from 'react-router';
+import { useHostNamespaceQuery } from 'src/api/queries/namespaces';
 
-// TODO this will not be necessary once `useActiveNamespace` is exposed in @openshift-console/dynamic-plugin-sdk
+const NamespaceContext = React.createContext<string>('');
+export const NamespaceContextProvider = NamespaceContext.Provider;
+export const useNamespaceContext = () => {
+  const namespace = React.useContext(NamespaceContext);
+  const validateQuery = useHostNamespaceQuery(namespace);
+  return {
+    namespace,
+    isValidatingNamespace: validateQuery.isLoading,
+    isNamespaceValid: !!validateQuery.data,
+    isAllNamespaces: !validateQuery.isLoading && (!namespace || namespace === '#ALL_NS#'),
+  };
+};
 
-export const NamespaceContext = React.createContext<string>('');
-export const useNamespaceContext = () => React.useContext(NamespaceContext);
+export const useRedirectOnInvalidNamespaceEffect = (href: string) => {
+  const { isValidatingNamespace, isNamespaceValid, isAllNamespaces } = useNamespaceContext();
+  const history = useHistory();
+  React.useEffect(() => {
+    if (!isValidatingNamespace && !isNamespaceValid && !isAllNamespaces) {
+      history.push(href);
+    }
+  }, [history, href, isAllNamespaces, isNamespaceValid, isValidatingNamespace]);
+};

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,7 +1,11 @@
 import { pipelineRunGVK } from 'src/api/queries/pipelines';
 import { PipelineRunKind } from 'src/reused/pipelines-plugin/src/types';
 
+export const appImportWizardAllNamespacesUrl = '/app-imports/new/all-namespaces';
+
 export const appImportWizardUrl = (namespace: string) => `/app-imports/new/ns/${namespace}`;
+
+export const appImportsAllNamespacesUrl = '/app-imports/all-namespaces';
 
 export const appImportsPageUrl = (namespace: string, pipelineGroupName?: string) =>
   `/app-imports/ns/${namespace}${pipelineGroupName ? `/${pipelineGroupName}` : ''}`;
@@ -13,3 +17,7 @@ export const pipelineRunUrl = (namespace: string, pipelineRun: PipelineRunKind) 
 
 export const pipelinesListUrl = (namespace: string, nameFilter?: string) =>
   `/dev-pipelines/ns/${namespace}${nameFilter ? `?name=${nameFilter}` : ''}`;
+
+export const projectDetailsAllNamespacesUrl = '/project-details/all-namespaces';
+
+export const addPageAllNamespacesUrl = '/add/all-namespaces';


### PR DESCRIPTION
This is a followup to https://github.com/konveyor/crane-ui-plugin/pull/118 (finishes fixing https://issues.redhat.com/browse/MTRHO-123). In that PR we enforced that the namespace should never be undefined, but we didn't handle the case where the user somehow ended up with a defined namespace in the URL that doesn't actually exist.

This PR replaces the `useNamespaceContext` hook with a `useValidatedNamespace` hook that actively tries to fetch the namespace specified in the URL, and it returns status and validity in addition to the namespace itself. Incidentally, it now gets the namespace directly from `useRouteMatch` instead of from context, which makes the entire `NamespaceContext` unnecessary, so this PR also removes `NamespaceContext`.

The AppImportsPage and the ImportWizard now show a loading state when the namespace is being validated, and if the namespace is found to be invalid the page automatically redirects to the "all-namespaces" URL (via the new `useRedirectOnInvalidNamespaceEffect` hook). This redirect is used so that we don't leave the invalid namespace in the URL at all, which would cause the whole console UI to try and use that namespace if you navigate away.

These "all-namespaces" URLs currently render the "No project selected" message and direct the user to go select a namespace. (If they reach this view on the Imports page, clicking "select a project" takes them to the Projects page, and if they reach it on the wizard page, clicking that takes them to the Add page. This UX will be improved when we address #106).

![Screen Shot 2022-07-27 at 1 36 03 PM](https://user-images.githubusercontent.com/811963/181312741-00d05588-004e-446a-8bff-6d535f290f1f.png)


Note that `useValidatedNamespace` is called all over the place, so the `useHostNamespaceQuery` within it will be mounted several times per page. This is okay because react-query will avoid unnecessary refetches and share the cached result. As a bonus though, the namespace will be re-validated whenever the page regains focus (as per react-query default behavior) so if the user goes and deletes their namespace and then returns to our page, they'll get kicked out.

This PR also factors out new components for `LoadingEmptyState` and `NoProjectEmptyState` since we're now duplicating this content on both pages.

With this change, it should now be impossible to end up in a state where our pages are rendered with a missing or invalid namespace, either through user interaction or manually typing an invalid URL. You can test it by:
* Trying to go to `/app-imports/ns/fakenamespace` or `/app-imports/new/ns/fakenamespace` and seeing that you get redirected to `/.../all-namespaces`.
* Going to the Add page, using the project switcher bar to select "All projects", then going to the Application Imports page and verifying that you still get redirected to `/app-imports/all-namespaces`.