### PR TITLE
RouteGuard: don't block navigation if only the URL query string is changing and pathname is remaining the same

### DIFF
--- a/src/common/components/RouteGuard.tsx
+++ b/src/common/components/RouteGuard.tsx
@@ -29,7 +29,7 @@ export const RouteGuard: React.FunctionComponent<IRouteGuard> = ({
 }) => {
   const history = useHistory();
   const [showRouteGuard, setShowRouteGuard] = React.useState(when);
-  const [currentPath, setCurrentPath] = React.useState('');
+  const [targetPath, setTargetPath] = React.useState('');
 
   const unblockFnRef = React.useRef<UnregisterCallback | null>(null);
   const unblock = () => {
@@ -43,8 +43,11 @@ export const RouteGuard: React.FunctionComponent<IRouteGuard> = ({
     if (when) {
       // When browser history routing happens (clicking links, back/forward) we can handle it with our custom modal.
       unblockFnRef.current = history.block((prompt) => {
-        setCurrentPath(prompt.pathname);
-        setShowRouteGuard(true);
+        // If only the query string is changing, don't interrupt the user.
+        if (history.location.pathname !== prompt.pathname) {
+          setTargetPath(prompt.pathname);
+          setShowRouteGuard(true);
+        }
         return false;
       });
       // When the page is being unloaded (closing or reloading tab), we have to trigger a native JS confirm dialog.
@@ -58,8 +61,8 @@ export const RouteGuard: React.FunctionComponent<IRouteGuard> = ({
 
   const handleOk = React.useCallback(() => {
     unblock();
-    history.push(currentPath);
-  }, [currentPath, history]);
+    history.push(targetPath);
+  }, [targetPath, history]);
 
   const handleCancel = React.useCallback(() => setShowRouteGuard(false), []);
 


### PR DESCRIPTION
Resolves #124.

The filter bar in the Select and Edit PVCs steps of the wizard is powered by the plugin SDK's ListPageFilter component. This component assumes we are on a console page that only lists resources, so it tries to update the `?name=` URL query string when you enter a name filter so that the filtered page is part of history and is preserved on back/forward/bookmark.

As a result, when you type in the filter box it is triggering updates to the history API, which our `RouteGuard` component is designed to block while you have unsaved changes. This is why it triggers the "Leave this page?" prompt.

This PR fixes the bug by simply not activating the prompt if the RouteGuard was triggered solely by a query string change (if the URL pathname is the same as before). Note that the history update event is **still blocked**, so we don't get the `?name=` query string in our URL, but that is actually a good thing since we don't want that filter sticking around between wizard steps. The block just happens silently rather than prompting the user, so the user will never notice that the URL attempted to change.

I also renamed the `currentPath` state variable to `targetPath` because that is what it really represents (the path we are attempting to navigate to that is being blocked), and `currentPath` was a little confusing.