### PR TITLE
MTRHO-129: Fix regression with cluster API URL validation, validate format of URL string

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/react": "^17.0.38",
     "@types/react-helmet": "^6.1.5",
     "@types/react-router-dom": "^5.3.2",
+    "@types/valid-url": "^1.0.3",
     "@types/webpack-dev-server": "^4.7.2",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.29.0",
@@ -88,5 +89,8 @@
     "dependencies": {
       "@console/pluginAPI": "*"
     }
+  },
+  "dependencies": {
+    "valid-url": "^1.0.9"
   }
 }

--- a/src/components/ImportWizard/ImportWizardFormContext.tsx
+++ b/src/components/ImportWizard/ImportWizardFormContext.tsx
@@ -32,7 +32,7 @@ export const useImportWizardFormState = () => {
     .required()
     .test('is-not-validating', (_value, context) => {
       if (sourceApiRootQuery.isLoading) {
-        return context.createError();
+        return context.createError({ message: 'Cannot connect using these credentials' });
       }
       return true;
     })

--- a/src/components/ImportWizard/ImportWizardFormContext.tsx
+++ b/src/components/ImportWizard/ImportWizardFormContext.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as yup from 'yup';
+import { isWebUri } from 'valid-url';
 import { useFormField, useFormState } from '@konveyor/lib-ui';
 import { OAuthSecret } from 'src/api/types/Secret';
 import { PersistentVolumeClaim } from 'src/api/types/PersistentVolume';
@@ -45,6 +46,11 @@ export const useImportWizardFormState = () => {
       }
       return true;
     });
+  const apiUrlSchema = credentialsFieldSchema.test(
+    'valid-url',
+    ({ label }) => `${label} must be a valid URL`,
+    (value) => !!value && !!isWebUri(value),
+  );
 
   const resetSourceSelections = () => {
     // If the source cluster/project is changing, reset everything the user has selected based on data from the source.
@@ -52,7 +58,7 @@ export const useImportWizardFormState = () => {
     forms.pvcEdit.clear();
   };
 
-  const apiUrlField = useFormField('', credentialsFieldSchema.label('Cluster API URL'), {
+  const apiUrlField = useFormField('', apiUrlSchema.label('Cluster API URL'), {
     onChange: resetSourceSelections,
   });
   const tokenField = useFormField('', credentialsFieldSchema.label('OAuth token'), {

--- a/src/components/ImportWizard/ImportWizardFormContext.tsx
+++ b/src/components/ImportWizard/ImportWizardFormContext.tsx
@@ -32,7 +32,7 @@ export const useImportWizardFormState = () => {
     .required()
     .test('is-not-validating', (_value, context) => {
       if (sourceApiRootQuery.isLoading) {
-        return context.createError({ message: 'Cannot connect using these credentials' });
+        return context.createError();
       }
       return true;
     })
@@ -147,7 +147,11 @@ export const useImportWizardFormState = () => {
         sourceApiSecret: sourceApiSecretField,
       },
       {
-        revalidateOnChange: [credentialsAreValid, validateSourceNamespaceQuery.data],
+        revalidateOnChange: [
+          credentialsAreValid,
+          validateSourceNamespaceQuery.data,
+          sourceApiRootQuery.status,
+        ],
       },
     ),
     pvcSelect: useFormState({

--- a/src/components/ImportWizard/SourceClusterProjectStep.tsx
+++ b/src/components/ImportWizard/SourceClusterProjectStep.tsx
@@ -19,6 +19,7 @@ import {
   useSourceApiRootQuery,
   useValidateSourceNamespaceQuery,
 } from 'src/api/queries/sourceResources';
+import { areSourceCredentialsValid } from 'src/api/proxyHelpers';
 import { useValidatedNamespace } from 'src/common/hooks/useValidatedNamespace';
 
 export const SourceClusterProjectStep: React.FunctionComponent = () => {
@@ -50,6 +51,13 @@ export const SourceClusterProjectStep: React.FunctionComponent = () => {
   const credentialsValidating =
     configureSourceSecretMutation.isLoading || sourceApiRootQuery.isLoading;
 
+  const credentialsAreValid = areSourceCredentialsValid(
+    form.fields.apiUrl,
+    form.fields.token,
+    form.fields.sourceApiSecret,
+    sourceApiRootQuery,
+  );
+
   const validateSourceNamespaceQuery = useValidateSourceNamespaceQuery(
     form.values.sourceApiSecret,
     form.values.sourceNamespace,
@@ -59,13 +67,13 @@ export const SourceClusterProjectStep: React.FunctionComponent = () => {
   // Override validation styles based on connection check.
   // Can't use greenWhenValid prop of ValidatedTextInput because fields can be valid before connection test passes.
   // This way we don't show the connection failed message when you just haven't finished entering credentials.
+  // The `validated: 'error'` case is handled in ValidatedTextInput based on the field schema.
   type validationFieldPropsType = {
     validating: boolean;
     valid: boolean;
     helperText?: React.ReactNode;
     labelIcon?: React.ReactElement;
   };
-
   const getAsyncValidationFieldProps = ({
     valid,
     validating,
@@ -86,7 +94,7 @@ export const SourceClusterProjectStep: React.FunctionComponent = () => {
 
   const apiUrlFieldProps = getAsyncValidationFieldProps({
     validating: credentialsValidating,
-    valid: form.fields.apiUrl.isValid,
+    valid: credentialsAreValid,
     labelIcon: (
       <Popover
         headerContent={`API URL of the source cluster`}
@@ -112,7 +120,7 @@ export const SourceClusterProjectStep: React.FunctionComponent = () => {
 
   const sourceTokenFieldProps = getAsyncValidationFieldProps({
     validating: credentialsValidating,
-    valid: form.fields.token.isValid,
+    valid: credentialsAreValid,
     labelIcon: (
       <Popover
         headerContent={`OAuth token of the source cluster`}

--- a/src/components/ImportWizard/SourceClusterProjectStep.tsx
+++ b/src/components/ImportWizard/SourceClusterProjectStep.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { isWebUri } from 'valid-url';
 import {
   TextContent,
   Popover,
@@ -38,7 +39,7 @@ export const SourceClusterProjectStep: React.FunctionComponent = () => {
 
   const configureSourceSecret = () => {
     const { apiUrl, token } = form.fields;
-    if ((apiUrl.isDirty || token.isDirty) && apiUrl.value && token.value) {
+    if ((apiUrl.isDirty || token.isDirty) && apiUrl.value && token.value && isApiUrlValidFormat) {
       configureSourceSecretMutation.mutate({ apiUrl: apiUrl.value, token: token.value });
     }
   };
@@ -48,8 +49,10 @@ export const SourceClusterProjectStep: React.FunctionComponent = () => {
     !configureSourceSecretMutation.isLoading,
   );
 
+  const isApiUrlValidFormat = !!isWebUri(form.fields.apiUrl.value);
   const credentialsValidating =
-    configureSourceSecretMutation.isLoading || sourceApiRootQuery.isLoading;
+    isApiUrlValidFormat &&
+    (configureSourceSecretMutation.isLoading || sourceApiRootQuery.isLoading);
 
   const credentialsAreValid = areSourceCredentialsValid(
     form.fields.apiUrl,
@@ -197,16 +200,18 @@ export const SourceClusterProjectStep: React.FunctionComponent = () => {
           // isTouched is already automatically set to true on blur
           {...sourceNamespaceFieldProps}
         />
-        <ResolvedQueries
-          spinnerMode="none"
-          resultsWithErrorTitles={[
-            {
-              result: configureSourceSecretMutation,
-              errorTitle: 'Cannot configure crane-reverse-proxy',
-            },
-            { result: sourceApiRootQuery, errorTitle: 'Cannot load cluster API versions' },
-          ]}
-        />
+        {isApiUrlValidFormat ? (
+          <ResolvedQueries
+            spinnerMode="none"
+            resultsWithErrorTitles={[
+              {
+                result: configureSourceSecretMutation,
+                errorTitle: 'Cannot configure crane-reverse-proxy',
+              },
+              { result: sourceApiRootQuery, errorTitle: 'Cannot load cluster API versions' },
+            ]}
+          />
+        ) : null}
       </Form>
       {form.isValid ? (
         <Alert

--- a/yarn.lock
+++ b/yarn.lock
@@ -857,6 +857,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/valid-url@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@types/valid-url/-/valid-url-1.0.3.tgz#a124389fb953559c7f889795a98620e91adb3687"
+  integrity sha512-+33x29mg+ecU88ODdWpqaie2upIuRkhujVLA7TuJjM823cNMbeggfI6NhxewaRaRF8dy+g33e4uIg/m5Mb3xDQ==
+
 "@types/webcola@3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@types/webcola/-/webcola-3.2.0.tgz#40abf867c5b32fd938e704b98819a5767c0c2547"
@@ -5189,6 +5194,11 @@ v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
+
+valid-url@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
+  integrity sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/MTRHO-129

In an earlier effort to simplify this validation as part of https://github.com/konveyor/crane-ui-plugin/pull/116, I forgot that the form schema's `isValid` property would end up `true` if the source cluster API request hadn't kicked off yet because the user hadn't entered both URL and token yet (because we don't want the fields turning red just because the user is still entering data). I thought I was being redundant by relying on the result of the API request to style the fields as green, so I changed it to use the schema's `isValid`. That was a mistake and resulted in the fields turning green if one had a value and the other did not.

This PR restores the original behavior of the validation styles on these fields, and also adds string format validation on the API URL field. We'll no longer attempt to configure the proxy if the URL is invalid, instead we'll immediately show an error. This PR also updates the `revalidateOnChange` criteria of the form so that it will always revalidate when the state of the source cluster API request changes, so we never end up with stale validation errors.