### PR TITLE
[WIP] Credential refresh feature

### DIFF
--- a/src/common/components/ConfirmModal.tsx
+++ b/src/common/components/ConfirmModal.tsx
@@ -19,6 +19,7 @@ export type UnknownMutationResult = Pick<
 
 export interface IConfirmModalProps {
   variant?: ModalProps['variant'];
+  className?: string;
   isOpen: boolean;
   toggleOpen: () => void;
   mutateFn: () => void;
@@ -34,6 +35,7 @@ export interface IConfirmModalProps {
 
 export const ConfirmModal: React.FunctionComponent<IConfirmModalProps> = ({
   variant = 'small',
+  className = '',
   isOpen,
   toggleOpen,
   mutateFn,
@@ -49,6 +51,7 @@ export const ConfirmModal: React.FunctionComponent<IConfirmModalProps> = ({
   isOpen ? (
     <Modal
       variant={variant}
+      className={className}
       title={title}
       isOpen
       onClose={toggleOpen}

--- a/src/common/components/HostTokenAlert.tsx
+++ b/src/common/components/HostTokenAlert.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { Alert } from '@patternfly/react-core';
+import { useValidatedNamespace } from '../hooks/useValidatedNamespace';
+
+interface HostTokenAlertProps {
+  className?: string;
+}
+
+export const HostTokenAlert: React.FunctionComponent<HostTokenAlertProps> = ({
+  className = '',
+}) => {
+  const { namespace } = useValidatedNamespace();
+  return (
+    <Alert
+      className={className}
+      variant="info"
+      isInline
+      isLiveRegion
+      title={
+        <>
+          If you proceed, your current session&apos;s OAuth token will be stored in a secret in the
+          &quot;{namespace}&quot; namespace.
+        </>
+      }
+    >
+      This allows the pipeline tasks to be performed with the required permissions.
+    </Alert>
+  );
+};

--- a/src/common/components/SourceTokenInput.tsx
+++ b/src/common/components/SourceTokenInput.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { Popover } from '@patternfly/react-core';
+import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
+import { IValidatedFormField, ValidatedPasswordInput } from '@konveyor/lib-ui';
+import { getAsyncValidationFieldProps } from '../helpers';
+
+interface SourceTokenInputProps {
+  field: IValidatedFormField<string>;
+  credentialsValidating: boolean;
+  credentialsAreValid: boolean;
+  configureSourceSecret: () => void;
+}
+
+export const SourceTokenInput: React.FunctionComponent<SourceTokenInputProps> = ({
+  field,
+  credentialsValidating,
+  credentialsAreValid,
+  configureSourceSecret,
+}) => {
+  return (
+    <ValidatedPasswordInput
+      field={field}
+      isRequired
+      fieldId="source-cluster-token"
+      onBlur={configureSourceSecret}
+      {...getAsyncValidationFieldProps({
+        validating: credentialsValidating,
+        valid: credentialsAreValid,
+        labelIcon: (
+          <Popover
+            headerContent={`OAuth token of the source cluster`}
+            bodyContent={
+              <span>
+                Can be found via <code>oc whoami -t</code>
+              </span>
+            }
+          >
+            <button
+              type="button"
+              aria-label="More info for oauth token field"
+              onClick={(e) => e.preventDefault()}
+              aria-describedby="token"
+              className="pf-c-form__group-label-help"
+            >
+              <HelpIcon noVerticalAlign />
+            </button>
+          </Popover>
+        ),
+        helperText: <>&nbsp;</>,
+      })}
+    />
+  );
+};

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -1,0 +1,27 @@
+import { TextInputProps, FormGroupProps } from '@patternfly/react-core';
+
+// Override validation styles based on async validation happening outside useFormState (e.g. the crane-reverse-proxy connection check).
+// Can't use greenWhenValid prop of ValidatedTextInput because fields can be valid before connection test passes.
+// This way we don't show the connection failed message when you just haven't finished entering credentials.
+export const getAsyncValidationFieldProps = ({
+  valid,
+  validating,
+  helperText,
+  labelIcon,
+}: {
+  validating: boolean;
+  valid: boolean;
+  helperText?: React.ReactNode;
+  labelIcon?: React.ReactElement;
+}) => {
+  const inputProps: Pick<TextInputProps, 'validated'> = {
+    ...(validating ? { validated: 'default' } : {}),
+    ...(valid ? { validated: 'success' } : {}),
+  };
+  const formGroupProps: Pick<FormGroupProps, 'validated' | 'helperText' | 'labelIcon'> = {
+    ...inputProps,
+    helperText: validating ? 'Validating...' : helperText,
+    labelIcon,
+  };
+  return { inputProps, formGroupProps };
+};

--- a/src/components/ImportedApps/ImportedApps.css
+++ b/src/components/ImportedApps/ImportedApps.css
@@ -6,7 +6,7 @@
   vertical-align: initial !important;
 }
 
-#update-credentials-modal span.pf-c-check__body {
+#update-credentials-form span.pf-c-check__body {
   width: 100%;
 }
 

--- a/src/components/ImportedApps/ImportedApps.css
+++ b/src/components/ImportedApps/ImportedApps.css
@@ -5,3 +5,11 @@
 #crane-imported-apps-page a span.co-icon-and-text.crane-plr-status svg {
   vertical-align: initial !important;
 }
+
+#update-credentials-modal span.pf-c-check__body {
+  width: 100%;
+}
+
+.crane-modal .pf-c-alert__title {
+  font-size: 14px; /* This was being computed as 16px but only in modals, something about global overrides in Console CSS. Temporary workaround */
+}

--- a/src/components/ImportedApps/PipelineGroupActionButton.tsx
+++ b/src/components/ImportedApps/PipelineGroupActionButton.tsx
@@ -12,6 +12,7 @@ import { CranePipelineAction, CranePipelineGroup } from 'src/api/types/CranePipe
 import { actionToString } from 'src/api/pipelineHelpers';
 import { ConfirmModal } from 'src/common/components/ConfirmModal';
 import { PipelineExplanation } from 'src/common/components/PipelineExplanation';
+import { UpdateCredentialsForm, useUpdateCredentialsFormState } from './UpdateCredentialsForm';
 
 interface PipelineGroupActionButtonProps {
   pipelineGroup: CranePipelineGroup;
@@ -70,16 +71,23 @@ export const PipelineGroupActionButton: React.FunctionComponent<PipelineGroupAct
     <>A stage or cutover cannot be run after a cutover is already succeeded.</>
   ) : null;
 
+  const { form } = useUpdateCredentialsFormState({ defaultExpanded: false });
+
   return (
     <>
       {disabledReason ? <Tooltip content={disabledReason}>{button}</Tooltip> : button}
       <ConfirmModal
         title={`Run ${action}?`}
+        className="crane-modal"
+        variant="medium"
         body={
-          <PipelineExplanation
-            action={action}
-            isStatefulMigration={pipelineGroup.isStatefulMigration}
-          />
+          <>
+            <PipelineExplanation
+              action={action}
+              isStatefulMigration={pipelineGroup.isStatefulMigration}
+            />
+            <UpdateCredentialsForm form={form} isStartingPipeline />
+          </>
         }
         confirmButtonText={actionToString(action)}
         isOpen={isConfirmModalOpen}

--- a/src/components/ImportedApps/PipelineGroupKebabMenu.tsx
+++ b/src/components/ImportedApps/PipelineGroupKebabMenu.tsx
@@ -7,6 +7,7 @@ import { isSomePipelineRunning, useDeletePipelineMutation } from 'src/api/querie
 import { pipelinesListUrl } from 'src/utils/paths';
 import { ConfirmModal } from 'src/common/components/ConfirmModal';
 import { useValidatedNamespace } from 'src/common/hooks/useValidatedNamespace';
+import { UpdateCredentialsModal } from './UpdateCredentialsModal';
 
 interface PipelineGroupKebabMenuProps {
   pipelineGroup: CranePipelineGroup;
@@ -26,6 +27,7 @@ export const PipelineGroupKebabMenu: React.FunctionComponent<PipelineGroupKebabM
   };
 
   const [isAppKebabOpen, toggleAppKebabOpen] = React.useReducer((isOpen) => !isOpen, false);
+  const [isUpdateCredentialsModalOpen, setIsUpdateCredentialsModalOpen] = React.useState(false);
 
   const onAppKebabSelect = () => {
     toggleAppKebabOpen();
@@ -62,11 +64,18 @@ export const PipelineGroupKebabMenu: React.FunctionComponent<PipelineGroupKebabM
             deleteItem
           ),
           <DropdownItem
-            key="app-view-pipelies"
+            key="app-view-pipelines"
             component="button"
             onClick={() => history.push(pipelinesListUrl(namespace, pipelineGroup.name))}
           >
             View pipelines
+          </DropdownItem>,
+          <DropdownItem
+            key="refresh-credentials"
+            component="button"
+            onClick={() => setIsUpdateCredentialsModalOpen(true)}
+          >
+            Update OAuth tokens
           </DropdownItem>,
         ]}
       />
@@ -86,6 +95,11 @@ export const PipelineGroupKebabMenu: React.FunctionComponent<PipelineGroupKebabM
         mutateFn={() => deletePipelineMutation.mutate(pipelineGroup.pipelines.cutover)}
         mutateResult={deletePipelineMutation}
         errorText="Cannot delete resources"
+      />
+      <UpdateCredentialsModal
+        pipelineGroup={pipelineGroup}
+        isOpen={isUpdateCredentialsModalOpen}
+        onClose={() => setIsUpdateCredentialsModalOpen(false)}
       />
     </>
   );

--- a/src/components/ImportedApps/UpdateCredentialsForm.tsx
+++ b/src/components/ImportedApps/UpdateCredentialsForm.tsx
@@ -32,16 +32,20 @@ export const useUpdateCredentialsFormState = ({
 
 interface UpdateCredentialsFormProps {
   form: ReturnType<typeof useUpdateCredentialsFormState>['form'];
+  isStartingPipeline?: boolean;
 }
 
 export const UpdateCredentialsForm: React.FunctionComponent<UpdateCredentialsFormProps> = ({
   form,
+  isStartingPipeline = false,
 }) => {
   return (
-    <Form isWidthLimited className={spacing.mtMd}>
+    <Form id="update-credentials-form" isWidthLimited className={spacing.mtMd}>
       <Checkbox
         id="update-source-token-checkbox"
-        label="Update OAuth token for source cluster"
+        label={
+          <>Update OAuth token for source cluster {isStartingPipeline ? 'before starting' : null}</>
+        }
         isChecked={form.values.isUpdatingSourceToken}
         onChange={form.fields.isUpdatingSourceToken.setValue}
         body={
@@ -59,7 +63,9 @@ export const UpdateCredentialsForm: React.FunctionComponent<UpdateCredentialsFor
       />
       <Checkbox
         id="update-target-token-checkbox"
-        label="Update OAuth token for target cluster"
+        label={
+          <>Update OAuth token for target cluster {isStartingPipeline ? 'before starting' : null}</>
+        }
         isChecked={form.values.isUpdatingTargetToken}
         onChange={form.fields.isUpdatingTargetToken.setValue}
         body={form.values.isUpdatingTargetToken ? <HostTokenAlert /> : null}

--- a/src/components/ImportedApps/UpdateCredentialsForm.tsx
+++ b/src/components/ImportedApps/UpdateCredentialsForm.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import * as yup from 'yup';
+import { Form, Checkbox } from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { useFormField, useFormState } from '@konveyor/lib-ui';
+import { HostTokenAlert } from 'src/common/components/HostTokenAlert';
+import { SourceTokenInput } from 'src/common/components/SourceTokenInput';
+
+interface UseUpdateCredentialsFormStateParams {
+  defaultExpanded: boolean;
+}
+
+export const useUpdateCredentialsFormState = ({
+  defaultExpanded,
+}: UseUpdateCredentialsFormStateParams) => {
+  const isUpdatingSourceTokenField = useFormField(defaultExpanded, yup.boolean());
+  const sourceTokenSchema = yup.string().label('Source cluster OAuth token'); // TODO look at original schema and validation from wizard
+  const isUpdatingTargetTokenField = useFormField(defaultExpanded, yup.boolean());
+  const form = useFormState({
+    isUpdatingSourceToken: isUpdatingSourceTokenField,
+    newSourceToken: useFormField(
+      '',
+      isUpdatingSourceTokenField.value ? sourceTokenSchema.required() : sourceTokenSchema,
+    ),
+    isUpdatingTargetToken: isUpdatingTargetTokenField,
+  });
+
+  return {
+    form,
+  };
+};
+
+interface UpdateCredentialsFormProps {
+  form: ReturnType<typeof useUpdateCredentialsFormState>['form'];
+}
+
+export const UpdateCredentialsForm: React.FunctionComponent<UpdateCredentialsFormProps> = ({
+  form,
+}) => {
+  return (
+    <Form isWidthLimited className={spacing.mtMd}>
+      <Checkbox
+        id="update-source-token-checkbox"
+        label="Update OAuth token for source cluster"
+        isChecked={form.values.isUpdatingSourceToken}
+        onChange={form.fields.isUpdatingSourceToken.setValue}
+        body={
+          form.values.isUpdatingSourceToken ? (
+            <SourceTokenInput
+              field={form.fields.newSourceToken}
+              credentialsValidating={false}
+              credentialsAreValid={false}
+              configureSourceSecret={() => {
+                // TODO
+              }}
+            />
+          ) : null
+        }
+      />
+      <Checkbox
+        id="update-target-token-checkbox"
+        label="Update OAuth token for target cluster"
+        isChecked={form.values.isUpdatingTargetToken}
+        onChange={form.fields.isUpdatingTargetToken.setValue}
+        body={form.values.isUpdatingTargetToken ? <HostTokenAlert /> : null}
+      />
+    </Form>
+  );
+};

--- a/src/components/ImportedApps/UpdateCredentialsModal.tsx
+++ b/src/components/ImportedApps/UpdateCredentialsModal.tsx
@@ -9,15 +9,6 @@ interface UpdateCredentialsModalProps {
   onClose: () => void;
 }
 
-// TODO: add field for pasting source cluster token, and repeat warning from first wizard step
-// TODO: validate before submitting? that's tricky... what if it's running (probably need to disable this while it's running)
-//       - maybe store the existing source token before letting the user edit it, and if they cancel, restore it on the secret before closing the modal?
-//       - or maybe create a separate temporary secret just for validation, and then delete it when we update the original? i like that more.
-// TODO: on submit, patch the source cluster secret with the new token, and patch the target cluster secret via crane-secret-service (noop? how to get that to just patch the token?)
-// TODO: when user clicks Stage or Cutover, somehow test the source and target tokens and prompt the user to reset them?
-//       - start with just a warning followed by opening this modal?
-//       - maybe instead: in the Stage or Cutover confirm modals themselves, add a checkbox for "update oauth tokens before starting" that defaults to checked? expand under it to show the body contents of this modal?
-//       - abstract just the fields into `UpdateCredentialsForm`? How to reuse the mutation itself? probably factor out into a shared useUpdateCredentialsMutation hook
 export const UpdateCredentialsModal: React.FunctionComponent<UpdateCredentialsModalProps> = ({
   pipelineGroup,
   isOpen,

--- a/src/components/ImportedApps/UpdateCredentialsModal.tsx
+++ b/src/components/ImportedApps/UpdateCredentialsModal.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { Button, Flex, Modal, Stack } from '@patternfly/react-core';
+// import { ResolvedQuery } from '@konveyor/lib-ui';
+import { CranePipelineGroup } from 'src/api/types/CranePipeline';
+
+interface UpdateCredentialsModalProps {
+  pipelineGroup: CranePipelineGroup;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const UpdateCredentialsModal: React.FunctionComponent<UpdateCredentialsModalProps> = ({
+  pipelineGroup,
+  isOpen,
+  onClose,
+}) => {
+  // TODO mutation for updating both the source and target secrets?
+  return (
+    <Modal
+      variant="medium"
+      title="Update OAuth Tokens"
+      isOpen={isOpen}
+      onClose={onClose}
+      footer={
+        <Stack hasGutter>
+          {/*mutateResult?.isError ? (
+          <ResolvedQuery result={mutateResult} errorTitle={errorText} spinnerMode="inline" />
+        ) : null*/}
+          <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+            <Button
+              id="modal-confirm-button"
+              key="confirm"
+              variant="primary"
+              onClick={() => {
+                // TODO
+              }}
+              // isDisabled={mutateResult?.isLoading || confirmButtonDisabled}
+            >
+              Update
+            </Button>
+            <Button
+              id="modal-cancel-button"
+              key="cancel"
+              variant="link"
+              onClick={onClose}
+              // isDisabled={mutateResult?.isLoading}
+            >
+              Cancel
+            </Button>
+          </Flex>
+        </Stack>
+      }
+    >
+      TODO
+    </Modal>
+  );
+};

--- a/src/components/ImportedApps/UpdateCredentialsModal.tsx
+++ b/src/components/ImportedApps/UpdateCredentialsModal.tsx
@@ -9,6 +9,15 @@ interface UpdateCredentialsModalProps {
   onClose: () => void;
 }
 
+// TODO: add field for pasting source cluster token, and repeat warning from first wizard step
+// TODO: validate before submitting? that's tricky... what if it's running (probably need to disable this while it's running)
+//       - maybe store the existing source token before letting the user edit it, and if they cancel, restore it on the secret before closing the modal?
+//       - or maybe create a separate temporary secret just for validation, and then delete it when we update the original? i like that more.
+// TODO: on submit, patch the source cluster secret with the new token, and patch the target cluster secret via crane-secret-service (noop? how to get that to just patch the token?)
+// TODO: when user clicks Stage or Cutover, somehow test the source and target tokens and prompt the user to reset them?
+//       - start with just a warning followed by opening this modal?
+//       - maybe instead: in the Stage or Cutover confirm modals themselves, add a checkbox for "update oauth tokens before starting" that defaults to checked? expand under it to show the body contents of this modal?
+//       - abstract just the fields into `UpdateCredentialsForm`? How to reuse the mutation itself? probably factor out into a shared useUpdateCredentialsMutation hook
 export const UpdateCredentialsModal: React.FunctionComponent<UpdateCredentialsModalProps> = ({
   pipelineGroup,
   isOpen,

--- a/src/components/ImportedApps/UpdateCredentialsModal.tsx
+++ b/src/components/ImportedApps/UpdateCredentialsModal.tsx
@@ -1,20 +1,7 @@
 import * as React from 'react';
-import * as yup from 'yup';
-import {
-  Button,
-  Flex,
-  Modal,
-  Stack,
-  TextContent,
-  Text,
-  Form,
-  Checkbox,
-} from '@patternfly/react-core';
-import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { useFormState, useFormField } from '@konveyor/lib-ui';
+import { Button, Flex, Modal, Stack, TextContent, Text } from '@patternfly/react-core';
 import { CranePipelineGroup } from 'src/api/types/CranePipeline';
-import { HostTokenAlert } from 'src/common/components/HostTokenAlert';
-import { SourceTokenInput } from 'src/common/components/SourceTokenInput';
+import { UpdateCredentialsForm, useUpdateCredentialsFormState } from './UpdateCredentialsForm';
 
 interface UpdateCredentialsModalProps {
   pipelineGroup: CranePipelineGroup;
@@ -36,16 +23,7 @@ export const UpdateCredentialsModal: React.FunctionComponent<UpdateCredentialsMo
   isOpen,
   onClose,
 }) => {
-  const [isUpdatingSourceToken, setIsUpdatingSourceToken] = React.useState(false);
-  const [isUpdatingTargetToken, setIsUpdatingTargetToken] = React.useState(false);
-
-  const sourceTokenSchema = yup.string().label('Source cluster OAuth token');
-  const form = useFormState({
-    newSourceToken: useFormField(
-      '',
-      isUpdatingSourceToken ? sourceTokenSchema.required() : sourceTokenSchema,
-    ),
-  });
+  const { form } = useUpdateCredentialsFormState({ defaultExpanded: true });
 
   // TODO mutation for updating both the source and target secrets?
   return (
@@ -70,7 +48,7 @@ export const UpdateCredentialsModal: React.FunctionComponent<UpdateCredentialsMo
                 // TODO
               }}
               isDisabled={
-                !(isUpdatingSourceToken || isUpdatingTargetToken) ||
+                !(form.values.isUpdatingSourceToken || form.values.isUpdatingTargetToken) ||
                 !form.isValid /* || mutateResult?.isLoading */
               }
             >
@@ -95,33 +73,7 @@ export const UpdateCredentialsModal: React.FunctionComponent<UpdateCredentialsMo
           with the source and target clusters during import.
         </Text>
       </TextContent>
-      <Form isWidthLimited className={spacing.mtMd}>
-        <Checkbox
-          id="update-source-token-checkbox"
-          label="Update OAuth token for source cluster"
-          isChecked={isUpdatingSourceToken}
-          onChange={setIsUpdatingSourceToken}
-          body={
-            isUpdatingSourceToken ? (
-              <SourceTokenInput
-                field={form.fields.newSourceToken}
-                credentialsValidating={false}
-                credentialsAreValid={false}
-                configureSourceSecret={() => {
-                  // TODO
-                }}
-              />
-            ) : null
-          }
-        />
-        <Checkbox
-          id="update-target-token-checkbox"
-          label="Update OAuth token for target cluster"
-          isChecked={isUpdatingTargetToken}
-          onChange={setIsUpdatingTargetToken}
-          body={isUpdatingTargetToken ? <HostTokenAlert /> : null}
-        />
-      </Form>
+      <UpdateCredentialsForm form={form} />
     </Modal>
   );
 };

--- a/src/components/ImportedApps/UpdateCredentialsModal.tsx
+++ b/src/components/ImportedApps/UpdateCredentialsModal.tsx
@@ -28,7 +28,6 @@ export const UpdateCredentialsModal: React.FunctionComponent<UpdateCredentialsMo
   // TODO mutation for updating both the source and target secrets?
   return (
     <Modal
-      id="update-credentials-modal"
       className="crane-modal"
       variant="medium"
       title="Update OAuth tokens"


### PR DESCRIPTION
This is a WIP, early design for how to prompt the user to update the oauth tokens in the secrets used by their pipelines.
It would resolve https://github.com/konveyor/crane-ui-plugin/issues/97 (https://issues.redhat.com/browse/MTRHO-93).

Posting it for posterity since development is being paused.

@vconzola and I had started design discussions about it, if we had continued development the next steps would be:
* Figure out if we can detect whether the tokens are about to expire, and only prompt the user to update them when starting Stage or Cutover if they will expire within X hours/days.
* Iterate on text and design
* Hook up validation on the token field, similarly to how it's done on the first step of the wizard (configure a secret for crane-reverse-proxy, test trying to load something from the source cluster, turns green if successful). Probably should use a separate temporary secret for this purpose rather than overwriting the existing secret before the user submits the modal, in case they click Cancel.
* Hook up a `useMutation` so that when submitting these forms, the following happens:
  * Delete any temporary secrets created for valdiation (see above)
  * If updating the source token is checked, patch the secret for the source cluster using the user-provided token
  * If updating the target token is checked, patch the secret for the target cluster via crane-secret-service to reattach the host cluster token that way
  * Proceed with the normal mutation for starting a stage or cutover, if we're in that form
  * Show any errors with any of this via `ResolvedQuery` on the mutation result-- this should all possibly be one big mutation with async/await for each step.
* ??? I'm sure we forgot stuff.