### PR TITLE
Replace `@konveyor/lib-ui` with `@migtools/lib-ui`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:fix": "yarn lint --fix"
   },
   "devDependencies": {
-    "@konveyor/lib-ui": "^8.3.2",
+    "@migtools/lib-ui": "^8.4.1",
     "@openshift-console/dynamic-plugin-sdk": "^0.0.12",
     "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.7",
     "@patternfly/patternfly": "^4.196.7",

--- a/src/api/proxyHelpers.ts
+++ b/src/api/proxyHelpers.ts
@@ -5,7 +5,7 @@ import {
   CoreClusterResourceKind,
   IFormField,
   KubeResource,
-} from '@konveyor/lib-ui';
+} from '@migtools/lib-ui';
 import { OAuthSecret } from './types/Secret';
 import { useSourceApiRootQuery } from './queries/sourceResources';
 import { secretMatchesCredentials } from './queries/secrets';

--- a/src/api/queries/sourceResources.ts
+++ b/src/api/queries/sourceResources.ts
@@ -1,6 +1,6 @@
 import { useQuery } from 'react-query';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
-import { CoreNamespacedResource } from '@konveyor/lib-ui';
+import { CoreNamespacedResource } from '@migtools/lib-ui';
 import {
   getSourceClusterApiUrl,
   namespaceResource,

--- a/src/common/components/ConfirmModal.tsx
+++ b/src/common/components/ConfirmModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Modal, Stack, Flex, Button, ModalProps, ButtonProps } from '@patternfly/react-core';
-import { ResolvedQuery } from '@konveyor/lib-ui';
+import { ResolvedQuery } from '@migtools/lib-ui';
 import { UseMutationResult, UseQueryResult } from 'react-query';
 
 // TODO export this from lib-ui? part of ResolvedQueries

--- a/src/components/ImportWizard/ImportWizard.tsx
+++ b/src/components/ImportWizard/ImportWizard.tsx
@@ -9,7 +9,7 @@ import {
   WizardStepFunctionType,
 } from '@patternfly/react-core';
 import wizardStyles from '@patternfly/react-styles/css/components/Wizard/wizard';
-import { IFormState, ResolvedQueries } from '@konveyor/lib-ui';
+import { IFormState, ResolvedQueries } from '@migtools/lib-ui';
 import { useHistory } from 'react-router-dom';
 
 import { SourceClusterProjectStep } from './SourceClusterProjectStep';

--- a/src/components/ImportWizard/ImportWizardFormContext.tsx
+++ b/src/components/ImportWizard/ImportWizardFormContext.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as yup from 'yup';
 import { isWebUri } from 'valid-url';
-import { useFormField, useFormState } from '@konveyor/lib-ui';
+import { useFormField, useFormState } from '@migtools/lib-ui';
 import { OAuthSecret } from 'src/api/types/Secret';
 import { PersistentVolumeClaim } from 'src/api/types/PersistentVolume';
 import { getCapacity } from 'src/utils/helpers';

--- a/src/components/ImportWizard/ImportWizardWelcomeModal.tsx
+++ b/src/components/ImportWizard/ImportWizardWelcomeModal.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button, Modal, TextContent, Text, Checkbox } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { useLocalStorage } from '@konveyor/lib-ui';
+import { useLocalStorage } from '@migtools/lib-ui';
 import { useValidatedNamespace } from 'src/common/hooks/useValidatedNamespace';
 
 export const ImportWizardWelcomeModal: React.FunctionComponent = () => {

--- a/src/components/ImportWizard/PVCEditStepTableRow.tsx
+++ b/src/components/ImportWizard/PVCEditStepTableRow.tsx
@@ -4,7 +4,7 @@ import { Button, Checkbox, MenuContent, MenuItem, MenuList } from '@patternfly/r
 import PencilAltIcon from '@patternfly/react-icons/dist/esm/icons/pencil-alt-icon';
 import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
-import { ValidatedTextInput } from '@konveyor/lib-ui';
+import { ValidatedTextInput } from '@migtools/lib-ui';
 
 import { PersistentVolumeClaim } from 'src/api/types/PersistentVolume';
 import { SimpleSelectMenu } from 'src/common/components/SimpleSelectMenu';

--- a/src/components/ImportWizard/PVCSelectStep.tsx
+++ b/src/components/ImportWizard/PVCSelectStep.tsx
@@ -9,7 +9,7 @@ import {
   RowFilter,
   useListPageFilter,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { ResolvedQuery, useSelectionState } from '@konveyor/lib-ui';
+import { ResolvedQuery, useSelectionState } from '@migtools/lib-ui';
 
 import { getCapacity, isSameResource } from 'src/utils/helpers';
 import { useSortState } from 'src/common/hooks/useSortState';

--- a/src/components/ImportWizard/PipelineSettingsStep.tsx
+++ b/src/components/ImportWizard/PipelineSettingsStep.tsx
@@ -3,7 +3,7 @@ import { TextContent, Text, Form } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 import { ImportWizardFormContext } from './ImportWizardFormContext';
-import { ValidatedTextInput } from '@konveyor/lib-ui';
+import { ValidatedTextInput } from '@migtools/lib-ui';
 
 export const PipelineSettingsStep: React.FunctionComponent = () => {
   const forms = React.useContext(ImportWizardFormContext);

--- a/src/components/ImportWizard/SourceClusterProjectStep.tsx
+++ b/src/components/ImportWizard/SourceClusterProjectStep.tsx
@@ -10,7 +10,7 @@ import {
   Alert,
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { ResolvedQueries, ValidatedPasswordInput, ValidatedTextInput } from '@konveyor/lib-ui';
+import { ResolvedQueries, ValidatedPasswordInput, ValidatedTextInput } from '@migtools/lib-ui';
 
 import { ImportWizardFormContext } from './ImportWizardFormContext';
 import { useConfigureSourceSecretMutation } from 'src/api/queries/secrets';

--- a/src/components/ImportWizard/SourceProjectDetailsStep.tsx
+++ b/src/components/ImportWizard/SourceProjectDetailsStep.tsx
@@ -15,7 +15,7 @@ import {
   useSourcePVCsQuery,
   useSourceServicesQuery,
 } from 'src/api/queries/sourceResources';
-import { ResolvedQueries } from '@konveyor/lib-ui';
+import { ResolvedQueries } from '@migtools/lib-ui';
 
 export const SourceProjectDetailsStep: React.FunctionComponent = () => {
   const forms = React.useContext(ImportWizardFormContext);

--- a/yarn.lock
+++ b/yarn.lock
@@ -145,19 +145,19 @@
   resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.3.1.tgz#b50a781709c81e10701004214340f25475a171a0"
   integrity sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw==
 
-"@konveyor/lib-ui@^8.3.2":
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/@konveyor/lib-ui/-/lib-ui-8.3.2.tgz#f7b5ac010ff96e505227ed9b5ae98ac0d1c26287"
-  integrity sha512-AZD00BB5Ju46OL2zci5qSdkxgull/UF5M9T2oUKOzxLa+af43/49Xvz9JTU1gBZFixJYDuWRWqblRlWxP9s6jw==
-  dependencies:
-    fast-deep-equal "^3.1.3"
-    react-query "^3.26.0"
-    yup "^0.32.9"
-
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
+
+"@migtools/lib-ui@^8.4.1":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@migtools/lib-ui/-/lib-ui-8.4.1.tgz#d10e33ab03ee9cd87ccb01e181451d2b79c5ec0b"
+  integrity sha512-QJEh3Vq7IkHcRCiOQh3NhX30b8BvHB1XBBkbGyp+lcwP90pPl/ateOJzac1v44OIa7DAgK4iNS+v+hay3EK5cg==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    react-query "^3.26.0"
+    yup "^0.32.9"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
The `@konveyor/lib-ui` package has been migrated from the `konveyor` org to the `migtools` org as part of Konveyor being [donated to the CNCF Sandbox](https://www.konveyor.io/blog/konveyor-is-a-cncf-sandbox-project/). The npm package has been renamed to `@migtools/lib-ui` starting with the `8.4.1` release (see https://github.com/migtools/lib-ui/pull/111).

The only changes since `@konveyor/lib-ui@8.3.2` were the addition of name change warnings in `8.4.0` and then the package rename in `8.4.1`, so renaming imports is the only source change necessary here.

See also:
* https://github.com/konveyor/forklift-ui/pull/984
* https://github.com/konveyor/forklift-console-plugin/pull/27
* https://github.com/konveyor/mig-ui/pull/1471
* https://github.com/konveyor/tackle2-ui/pull/375